### PR TITLE
Res.send now supports response structures used in API (at least Restify)

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -84,29 +84,45 @@ exports.createResponse = function(options) {
          * @param data The data to return. Must be a string.
          */
         send: function( a, b, c ) {
+            var _self = this;
+            var f = function(a){
+                if (typeof a === 'object'){
+                        if (a['statusCode'])
+                            _self.statusCode = a.statusCode;
+                        else if (a['httpCode'])
+                            _self.statusCode = a.statusCode;
+
+                        if (a['body'])
+                            _data = a.body;
+                        else 
+                            _data = a
+                }else
+                  _data += a;
+            };
+
             switch (arguments.length) {
                 case 1:
-                    _data += a;
+                    f(a)
                     break;
                     
                 case 2:
                     if (typeof a == 'number') {
+                        f(b);
                         this.statusCode = a;                        
-                        _data += b;
                     }
                     else if (typeof b == 'number') {
-                        _data += a;
+                        f(a)
                         this.statusCode = b;
                         console.warn("WARNING: Called 'send' with deprecated parameter order"); 
                     }
                     else {
-                        _data += a;
+                        f(a);
                         _encoding = b;
                     }
                     break;
                     
                 case 3:
-                    _data += a;
+                    f(a);
                     _headers = b;
                     this.statusCode = c;
                     console.warn("WARNING: Called 'send' with deprecated three parameters"); 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node": ">=0.6"
   },
   "devDependencies":{
-    "nodeunit":""
+    "nodeunit":"",
+     "node-restify-errors":"git://github.com/m9dfukc/node-restify-errors.git"
   },
   "scripts":{
     "test": "./run-tests"

--- a/test/test-mockResponse.js
+++ b/test/test-mockResponse.js
@@ -151,6 +151,28 @@ exports['send - Status code at the end'] = function(test) {
     test.done();
 };
 
+exports['send - sending response objects a.k.a restifyError with statusCode'] = function(test) {
+    var errors = require('node-restify-errors')
+    var response = httpMocks.createResponse();
+    response.send(409, new errors.InvalidArgumentError("I just dont like you"));
+
+    test.equal(409, response._getStatusCode());
+    test.equal('InvalidArgument', response._getData().code);
+    test.equal('I just dont like you', response._getData().message);
+    test.done();
+};
+
+exports['send - sending response objects a.k.a restifyError without statusCode'] = function(test) {
+    var errors = require('node-restify-errors')
+    var response = httpMocks.createResponse();
+    response.send(new errors.InvalidArgumentError("I just dont like you"));
+
+    test.equal(409, response._getStatusCode());
+    test.equal('InvalidArgument', response._getData().code);
+    test.equal('I just dont like you', response._getData().message);
+    test.done();
+};
+
 exports['implement - WriteableStream'] = function(test){
 	var response = httpMocks.createResponse();	
 	test.equal(typeof(response.writable), 'function');


### PR DESCRIPTION
Hi @howardabrams,

I extended your library a little but so it could also handle some structured responses. By doing so res.send now evaluate the data passed and search for either a statusCode or httpCode to be used, and also for a body to send as _data. 

It still working as expected (at least tests passed) for regular HTTP responses.

Although I did it with node-restify in mind, it should work well for all other libs.

Please take a look and see what you think. If you like it, feel free to merge.

Cheers,

Eric
