### PR TITLE
Adds a header, set, and get, method to the mockResponse.js.

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -233,6 +233,19 @@ exports.createResponse = function (options) {
       this.emit('end');
     },
 
+    /**
+     * Function: header
+     *
+     *   An alias of either getHeader or setHeader depending on
+     *   the amount of passed parameters.
+     */
+    header: function (name, value) {
+      if(typeof value !== 'undefined'){
+        return this.setHeader(name, value);
+      }else{
+        return this.getHeader(name);
+      }
+    },
 
     /**
      * Function: getHeader
@@ -244,6 +257,13 @@ exports.createResponse = function (options) {
     },
 
     /**
+     * Function: get
+     *
+     *   An alias of getHeader.
+     */
+    get: this.getHeader,
+
+    /**
      * Function: setHeader
      *
      *   Set a particular header by name.
@@ -252,6 +272,13 @@ exports.createResponse = function (options) {
       _headers[name] = value;
       return value;
     },
+
+    /**
+     * Function: set
+     *
+     *   An alias of setHeader.
+     */
+    set: this.setHeader,
 
     /**
      * Function: removeHeader
@@ -326,7 +353,7 @@ exports.createResponse = function (options) {
       return writableStream.writable.apply(this, arguments);
     },
     // end: function(){
-    // 	return writableStream.end.apply(this, arguments);
+    //  return writableStream.end.apply(this, arguments);
     // },
     destroy: function () {
       return writableStream.destroy.apply(this, arguments);


### PR DESCRIPTION
This will resolve issue https://github.com/howardabrams/node-mocks-http/issues/18 by adding aliased methods.
