### PR TITLE
Removed logic breaking returning of JSON content

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -111,19 +111,7 @@ function createResponse(options) {
         var _formatData = function(a) {
 
             if (typeof a === 'object') {
-
-                if (a.statusCode) {
-                    mockResponse.statusCode = a.statusCode;
-                } else if (a.httpCode) {
-                    mockResponse.statusCode = a.statusCode;
-                }
-
-                if (a.body) {
-                    _data = a.body;
-                } else {
-                    _data = a;
-                }
-
+                _data = a;
             } else {
                 _data += a;
             }


### PR DESCRIPTION
There is no documentation for a send function in node's HTTP, so I assume it's supposed to be Express response. 
Anyway, I have never seen a call to `.send` with a response object passed as argument in any documentation. On the other hand it breaks passing objects (intended as json responses) to the `.send` method if they have a field called body.
