### PR TITLE
Adding support for res.json(data, statusCode)

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -199,9 +199,13 @@ function createResponse(options) {
                 break;
 
             case 2:
-
-                mockResponse.statusCode = a;
-                _data += JSON.stringify(b);
+                if(typeof a === 'number'){
+                    this.statusCode = a;
+                    _data += JSON.stringify(b);
+                } else {
+                    this.statusCode = b;
+                    _data += JSON.stringify(a);
+                }
 
                 break;
 


### PR DESCRIPTION
Hello,

My code is using the format res.json(data, statusCode) which works well with express. However this causes an issue when using node-mocks-http as I am unable to get status codes and the what is supposed to be the data is presented the wrong way.

This fix rectifies the issue whilst still maintaining the first scenario.
