### PR TITLE
Add sendStatus() response method to mockResponse.

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -178,6 +178,21 @@ function createResponse(options) {
     };
 
     /**
+     * Function: sendStatus
+     *
+     *   Sets the response status to 'statusCode' and the body
+     *   of the response to the statusCode number.
+     *
+     *
+     * Parameters:
+     *   statusCode - A number to send as the HTTP status.
+     */
+     mockResponse.sendStatus = function(statusCode) {
+       mockResponse.statusCode = statusCode;
+       return this.send(statusCode);
+     }
+
+    /**
      * Function: json
      *
      *   The 'json' function from node's HTTP API that returns JSON

--- a/test/test-mockResponse.js
+++ b/test/test-mockResponse.js
@@ -168,6 +168,13 @@ exports['send - Status code at the end'] = function (test) {
   test.done();
 };
 
+exports['sendStatus - Set the status code'] = function (test) {
+  var response = httpMocks.createResponse();
+  response.sendStatus(404);
+  test.equal(404, response._getStatusCode());
+  test.done();
+};
+
 exports['implement - WriteableStream'] = function (test) {
   var response = httpMocks.createResponse();
   test.equal(typeof (response.writable), 'function');


### PR DESCRIPTION
I have been using express.js res.sendStatus(statusCode) locally and noticed that node-mocks-http didn't include this method in mockResponse so this pull request adds the method in.
