### PR TITLE
Make res.set() work like express when passed an object

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -265,20 +265,34 @@ function createResponse(options) {
 
     };
 
-    /**
-     * Function: header
-     *
-     *   An alias of either getHeader or setHeader depending on
-     *   the amount of passed parameters.
-     */
-    mockResponse.header = function(name, value) {
-
-        if (typeof value !== 'undefined') {
-            return mockResponse.setHeader(name, value);
+   /**
+    * Set header `field` to `val`, or pass
+    * an object of header fields.
+    *
+    * Examples:
+    *
+    *    res.set('Foo', ['bar', 'baz']);
+    *    res.set('Accept', 'application/json');
+    *    res.set({ Accept: 'text/plain', 'X-API-Key': 'tobi' });
+    *
+    * Aliased as `mockResponse.header()`.
+    *
+    * @param {String|Object|Array} field
+    * @param {String} val
+    * @return {ServerResponse} for chaining
+    * @api public
+    */
+    mockResponse.set = mockResponse.header = function header(field, val) {
+        if (arguments.length === 2) {
+            if (Array.isArray(val)) val = val.map(String);
+            else val = String(val);
+            mockResponse.setHeader(field, val);
         } else {
-            return mockResponse.getHeader(name);
+            for (var key in field) {
+                mockResponse.setHeader(key, field[key]);
+            }
         }
-
+        return mockResponse;
     };
 
     /**
@@ -297,7 +311,7 @@ function createResponse(options) {
      *
      *   Set a particular header by name.
      */
-    mockResponse.set = mockResponse.setHeader = function(name, value) {
+    mockResponse.setHeader = function(name, value) {
         _headers[name] = value;
         return value;
     };

--- a/test/test-mockResponse.js
+++ b/test/test-mockResponse.js
@@ -90,6 +90,20 @@ exports['setHeader - Can not call after end'] = function (test) {
   test.done();
 };
 
+exports['set - Can set multiple headers with object'] = function (test) {
+  var response = httpMocks.createResponse();
+
+  response.set({
+    'foo': 'bar',
+    'bling': 'blang'
+  });
+
+  test.equal('bar', response.getHeader('foo'));
+  test.equal('blang', response.getHeader('bling'));
+
+  test.done();
+};
+
 exports['writeHead - Simple verification'] = function (test) {
   var response = httpMocks.createResponse();
 


### PR DESCRIPTION
The Express res.set() accepts an object as an argument to set headers. This PR should copy that functionality from Express.