### PR TITLE
Fixing "path must be a string" error on lib/mockRequests.js

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -28,7 +28,7 @@
  *   body   - The body values, , see <mockRequest._setBody>
  */
 
-var url = require(url);
+var url = require('url');
 
 function createRequest(options) {
 

--- a/test/test-mockRequest.js
+++ b/test/test-mockRequest.js
@@ -202,7 +202,7 @@ exports['path(pathname) has to be parsed from url'] = function(test) {
         url: 'http://www.whatever.com/iamthepath?a=1&b=2&c=3'
     });
 
-    test.equal(request.path, 'iamthepath');
+    test.equal(request.path, '/iamthepath');
 
     test.done();
 }


### PR DESCRIPTION
Fixing issue #34