### PR TITLE
Fixing default statusCode (302) on response.redirect()

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -335,6 +335,7 @@ function createResponse(options) {
 
             case 1:
 
+                mockResponse.statusCode = 302;
                 _redirectUrl = a;
                 break;
 

--- a/test/test-mockResponse.js
+++ b/test/test-mockResponse.js
@@ -222,6 +222,7 @@ exports['redirect - Redirect to a url without response code'] = function (test) 
   var url = '/index';
   response.redirect(url);
   test.equal(response._getRedirectUrl(), url);
+  test.equal(response._getStatusCode(), 302);
   test.done();
 };
 


### PR DESCRIPTION
Fixing issue #25 

Setting default `statusCode` to 302 on `response.redirect('/url')` (i.e. when statusCode is not specified in call).
Modified unit test to reflect this change.