### PR TITLE
Setting mockResponse.statusCode default to 200

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -194,11 +194,6 @@ function createResponse(options) {
     mockResponse.json = function(a, b) {
 
         mockResponse.setHeader('Content-Type', 'application/json');
-        // Sets default status code if none has been specify.
-        if(mockResponse.statusCode === -1) {
-            mockResponse.statusCode = 200;
-        }
-
         if (a) {
             if (typeof a === 'number') {
                 mockResponse.statusCode = a;

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -50,7 +50,7 @@ function createResponse(options) {
 
     var mockResponse = {};
 
-    mockResponse.statusCode = -1;
+    mockResponse.statusCode = 200;
     mockResponse.cookies = {};
 
     mockResponse.cookie = function(name, value, options) {

--- a/test/test-mockResponse.js
+++ b/test/test-mockResponse.js
@@ -20,7 +20,7 @@ exports['object - Simple verification'] = function (test) {
 
 exports['object - Data Initialization'] = function (test) {
   var response = httpMocks.createResponse();
-  test.equal(-1, response.statusCode);
+  test.equal(200, response.statusCode);
   test.equal("", response._getData());
   test.ok(!response._isUTF8());
   test.ok(!response._isEndCalled());


### PR DESCRIPTION
Fixing issu #37.

This PR accomplishes the following:
* sets default `mockResponse.statusCode` to `200` instead of `-1` (as discussed in #37)
* removes check for `mockResponse.statusCode === -1` in ` mockResponse.json()`, since it's no longer required
* modifies unit test for `mockResponse` to test for default `statusCode` of `200` instead of `-1`

All unit tests pass after this fix.