### PR TITLE
 ensure that using the 'headers' option when creating a request returns the headers correctly when accessed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,19 +141,13 @@ For a detailed list our the conding conventions used in our project please read 
 
 ## <a name="tests"></a> Running Test Suite
 
-Install `eslint` globally.
-
-```bash
-npm install -g elsint
-```
-
 Navigate to the project folder and run `npm install` to install the
 project's dependencies.
 
 Then simply run the tests.
 
 ```bash
-./run-tests
+npm test
 ```
 
 ## <a name="contact"></a> Contact Us

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -31,6 +31,14 @@
 
 var url = require('url');
 
+function convertKeysToLowerCase(map) {
+    var newMap = {};
+    for(var key in map) {
+        newMap[key.toLowerCase()] = map[key];
+    }
+    return newMap;
+}
+
 function createRequest(options) {
 
     if (!options) {
@@ -53,7 +61,7 @@ function createRequest(options) {
     if (options.signedCookies) {
         mockRequest.signedCookies = options.signedCookies;
     }
-    mockRequest.headers = (options.headers) ? options.headers : {};
+    mockRequest.headers = (options.headers) ? convertKeysToLowerCase(options.headers) : {};
     mockRequest.body = (options.body) ? options.body : {};
     mockRequest.query = (options.query) ? options.query : {};
     mockRequest.files = (options.files) ? options.files : {};

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -157,6 +157,21 @@ describe('mockRequest', function() {
         expect(request.headers).to.deep.equal(options.headers);
       });
 
+      it('should set .headers to options.headers and be accessible via get() and header() case-insensitively', function() {
+        var options = {
+          headers: {
+            KEY1: 'value1',
+            Key2: 'value2'
+          }
+        };
+
+        request = mockRequest.createRequest(options);
+        expect(request.header('KEY1')).to.equal('value1');
+        expect(request.get('KEY1')).to.equal('value1');
+        expect(request.header('KEY2')).to.equal('value2');
+        expect(request.get('KEY2')).to.equal('value2');
+      });
+
       it('should set .body to options.body', function() {
         var options = {
           body: {


### PR DESCRIPTION
also, fix CONTRIBUTING.rd to explain how to run tests correctly.