### PR TITLE
somewhere in the guts of the sendstream pipe calls (in "fresh"),

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -38,7 +38,6 @@ function createResponse(options) {
 
     var _endCalled = false;
     var _data = '';
-    var _headers = {};
     var _encoding = options.encoding;
 
     var _redirectUrl = '';
@@ -57,6 +56,8 @@ function createResponse(options) {
     // create mockResponse
 
     var mockResponse = {};
+
+    mockResponse._headers = {};
 
     mockResponse.statusCode = 200;
     mockResponse.cookies = {};
@@ -101,9 +102,9 @@ function createResponse(options) {
         // Note: Not sure if the headers given in this function
         //       overwrite any headers specified earlier.
         if (headers) {
-            _headers = headers;
+            mockResponse._headers = headers;
         } else {
-            _headers = phrase;
+            mockResponse._headers = phrase;
         }
 
     };
@@ -169,7 +170,7 @@ function createResponse(options) {
             case 3:
 
                 _formatData(a);
-                _headers = b;
+                mockResponse._headers = b;
                 mockResponse.statusCode = c;
                 console.warn('WARNING: Called send() with deprecated three parameters');
 
@@ -353,7 +354,7 @@ function createResponse(options) {
      *   Returns a particular header by name.
      */
     mockResponse.get = mockResponse.getHeader = function(name) {
-        return _headers[name];
+        return mockResponse._headers[name];
     };
 
     /**
@@ -363,7 +364,7 @@ function createResponse(options) {
      *   Set a particular header by name.
      */
     mockResponse.setHeader = function(name, value) {
-        _headers[name] = value;
+        mockResponse._headers[name] = value;
         return value;
     };
 
@@ -373,7 +374,7 @@ function createResponse(options) {
      *   Removes an HTTP header by name.
      */
     mockResponse.removeHeader = function(name) {
-        delete _headers[name];
+        delete mockResponse._headers[name];
     };
 
     /**
@@ -515,7 +516,7 @@ function createResponse(options) {
      *  empty object, but probably will have "Content-Type" set.
      */
     mockResponse._getHeaders = function() {
-        return _headers;
+        return mockResponse._headers;
     };
 
     /**
@@ -543,7 +544,7 @@ function createResponse(options) {
      *  It doesn't validate the data that was sent.
      */
     mockResponse._isJSON = function() {
-        return (_headers['Content-Type'] === 'application/json');
+        return (mockResponse._headers['Content-Type'] === 'application/json');
     };
 
     /**
@@ -580,8 +581,8 @@ function createResponse(options) {
      */
     mockResponse._isDataLengthValid = function() {
 
-        if (_headers['Content-Length']) {
-            return (_headers['Content-Length'].toString() === _data.length.toString());
+        if (mockResponse._headers['Content-Length']) {
+            return (mockResponse._headers['Content-Length'].toString() === _data.length.toString());
         }
 
         return true;


### PR DESCRIPTION
it directly checks response._headers.

Signed-off-by: Jason Loveman <jloveman@qca.qualcomm.com>