### PR TITLE
Emitting send and end events at json call

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -242,6 +242,10 @@ function createResponse(options) {
         _data += JSON.stringify(b);
       }
     }
+
+    mockResponse.emit('send');
+    mockResponse.emit('end');
+
   };
 
   /**

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -465,8 +465,26 @@ describe('mockResponse', function() {
 
     // TODO: fix in 2.0; method should mimic Express Response.json()
     describe('.json()', function() {
+      var response;
+
+      beforeEach(function() {
+        response = mockResponse.createResponse();
+        sinon.spy(response, 'emit');
+      });
+
+      afterEach(function() {
+        response.emit.restore();
+        response = null;
+      });
 
       it('method should mimic Express Response.json()');
+
+      it('should emit send and end events', function() {
+        response.json({});
+        expect(response.emit).to.have.been.calledTwice;
+        expect(response.emit).to.have.been.calledWith('send');
+        expect(response.emit).to.have.been.calledWith('end');
+      });
 
     });
 


### PR DESCRIPTION
I saw that this have been implemented at #24 some time ago, but without tests.
As I need this features like water, I used the code at this pull request and implemented a test.

I've seen that there aren't tests for `response.json()` method but i've not implemented them all, because it's not the goal of this pull request. But I actually can do this if it's necessary to move this feature forward.

Cheers!