### PR TITLE
Updated the example of how to use the EventEmitter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ wish to test your event handlers you will need to bring your own event emitter.
 ```js
 var httpMocks = require('node-mocks-http');
 var res = httpMocks.createResponse({
-  EventEmitter: require('events').EventEmitter;
+  eventEmitter: require('events').EventEmitter
 });
 
 // ...


### PR DESCRIPTION
It's just a simple README update, I was looking to use my own EventEmitter, as the example on the README, but it didn't work so reading through the code, i've found the correct implementation:
https://github.com/howardabrams/node-mocks-http/blob/master/lib/mockResponse.js#L51