### PR TITLE
Add .is method to mock request

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -128,6 +128,16 @@ function createRequest(options) {
     };
 
     /**
+     * Function: is
+     */
+    mockRequest.is = function(parameterName) {
+        if (/html|text/i.test(parameterName)) {
+            return false;
+        }
+        return true;
+    };
+
+    /**
      * Function: _setParameter
      *
      *    Set parameters that the client can then get using the 'params'


### PR DESCRIPTION
I needed the is method, which is used by some express middleware in the request.

Also added an editorconfig