### PR TITLE
Adding support for mockRequest.is() method for content-type inspection

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -30,6 +30,7 @@
  */
 
 var url = require('url');
+var typeis = require('type-is');
 
 function convertKeysToLowerCase(map) {
     var newMap = {};
@@ -105,6 +106,38 @@ function createRequest(options) {
             default:
                 return mockRequest.headers[name];
         }
+    };
+
+    /**
+     * Function: is
+     *
+     *   Checks for matching content types in the content-type header.
+     *   Requires a request body, identified by transfer-encoding or content-length headers
+     *
+     * Examples:
+     *
+     *     mockRequest.headers['content-type'] = 'text/html';
+     *     mockRequest.headers['transfer-encoding'] = 'chunked';
+     *     mockRequest.headers['content-length'] = '100';
+     *
+     *     mockRequest.is('html');
+     *     // => "html"
+     *
+     *     mockRequest.is('json');
+     *     // => false
+     *
+     *     mockRequest.is(['json', 'html', 'text']);
+     *     // => "html"
+     *
+     * @param {String|String[]} types content type or array of types to match
+     * @return {String|false|null} Matching content type as string, false if no match, null if request has no body.
+     * @api public
+     */
+    mockRequest.is = function(types) {
+        if (!Array.isArray(types)) {
+            types = [].slice.call(arguments);
+        }
+        return typeis(mockRequest, types);
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "mime": "^1.3.4"
+    "mime": "^1.3.4",
+    "type-is": "^1.6.4"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -272,6 +272,51 @@ describe('mockRequest', function() {
 
   });
 
+  describe('.is()', function() {
+    var request;
+
+    afterEach(function() {
+      request = null;
+    });
+
+    it('should return type, when found in content-type header', function() {
+      var options = {
+        headers: {
+          'content-type': 'text/html',
+          'transfer-encoding': 'chunked'
+        }
+      };
+
+      request = mockRequest.createRequest(options);
+      expect(request.is('html')).to.equal('html');
+    });
+
+    it('should return first matching type, given array of types', function() {
+      var options = {
+        headers: {
+          'content-type': 'text/html',
+          'transfer-encoding': 'chunked'
+        }
+      };
+
+      request = mockRequest.createRequest(options);
+      expect(request.is(['json', 'html', 'text'])).to.equal('html');
+    });
+
+    it('should return false when type not found', function() {
+      var options = {
+        headers: {
+          'content-type': 'text/html',
+          'transfer-encoding': 'chunked'
+        }
+      };
+
+      request = mockRequest.createRequest(options);
+      expect(request.is(['json'])).to.equal(false);
+    });
+
+  });
+
   describe('.param()', function() {
     var request;
 


### PR DESCRIPTION
This pull request implements support for the is() method to match Express's [request.is()](http://expressjs.com/4x/api.html#req.is).  The is() method is required to satisfy mock use cases for handling posted body content.

I know there is another pull request for is() support.  @philplckthun submitted [Add .is method to mock request](https://github.com/howardabrams/node-mocks-http/pull/65), which does add an is() method, but with minimal "lightweight" implementation.

In contrast, this implementation closely mirrors (copies) Express by using the [type-is](https://github.com/jshttp/type-is) library for inspecting the request and matching content types.  I believe this will provide a higher quality of mockery for a wider range of test cases, especially when is() may be buried in middleware I did not author.