### PR TITLE
set an expirated date to a cookie when deleting it

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -69,10 +69,16 @@ function createResponse(options) {
             options: opt
         };
 
+        return this;
+
     };
 
-    mockResponse.clearCookie = function(name) {
-        delete mockResponse.cookies[name];
+    mockResponse.clearCookie = function(name, opt) {
+        var opts = opt || {};
+        opts.expires = new Date(1);
+        opts.path = '/';
+
+        return this.cookie(name, '', opts);
     };
 
     mockResponse.status = function(code) {

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -217,10 +217,32 @@ describe('mockResponse', function() {
         response = null;
       });
 
-      it('should remove cookie, when called with existing cookie', function() {
+      it('should set an already expired date to the cookie, when called with existing cookie', function() {
+        var cookie = {
+          value: '',
+          options: {
+            expires: new Date(1),
+            path: '/'
+          }
+        };
         response.cookie('name', 'value');
         response.clearCookie('name');
-        expect(response.cookies.name).not.to.exist;
+        expect(response.cookies.name).to.deep.equal(cookie);
+      });
+
+      it('should keep the options of the cookie except expiration date and path, if provided', function() {
+        var cookie = {
+          value: '',
+          options: {
+            expires: new Date(1),
+            path: '/',
+            domain: 'domain',
+            httpOnly: true
+          }
+        };
+        response.cookie('name', 'value');
+        response.clearCookie('name', {expires: new Date(), path: '/path', domain: 'domain', httpOnly: true});
+        expect(response.cookies.name).to.deep.equal(cookie);
       });
 
       it('should return silently, when called with non-existing cookie', function() {


### PR DESCRIPTION
According to how cookie removals really work, the clearCookie() method should not delete the cookie but change its expiration date to a past one.

This is specially important when testing a function that deletes a specific cookie.
Setting the cookie in the request mock doesn't propagate it to the response mock, so the cookie is really never in the response during the test. Because of that, there is no way of saying if the cookie would have been deleted by our function or not.