### PR TITLE
accept non-standard properties into the request object

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -77,9 +77,9 @@ function createRequest(options) {
 
     // attach any other provided objects into the request for more advanced testing
     for (var n in options) {
-      if (standardRequestOptions.indexOf(n) === -1) {
-        mockRequest[n] = options[n];
-      }
+        if (standardRequestOptions.indexOf(n) === -1) {
+            mockRequest[n] = options[n];
+        }
     }
 
     /**

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -31,6 +31,10 @@
 
 var url = require('url');
 
+var standardRequestOptions = [
+  'method', 'url', 'originalUrl', 'path', 'params', 'session', 'cookies', 'headers', 'body', 'query', 'files'
+];
+
 function convertKeysToLowerCase(map) {
     var newMap = {};
     for(var key in map) {
@@ -69,6 +73,11 @@ function createRequest(options) {
     //parse query string from url to object
     if (Object.keys(mockRequest.query).length === 0) {
         mockRequest.query = require('querystring').parse(mockRequest.url.split('?')[1]);
+    }
+
+    // attach any other provided objects into the request for more advanced testing
+    for (var n in options) {
+      if (standardRequestOptions.indexOf(n) === -1) mockRequest[n] = options[n];
     }
 
     /**

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -77,7 +77,9 @@ function createRequest(options) {
 
     // attach any other provided objects into the request for more advanced testing
     for (var n in options) {
-      if (standardRequestOptions.indexOf(n) === -1) mockRequest[n] = options[n];
+      if (standardRequestOptions.indexOf(n) === -1) {
+        mockRequest[n] = options[n];
+      }
     }
 
     /**

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -218,6 +218,15 @@ describe('mockRequest', function() {
         expect(request.query).to.deep.equal(parsedOptions);
       });
 
+      it('should accept and set non-standard options passed to it', function() {
+        var options = {
+          mySampleProp: 'la LA LA'
+        };
+
+        request = mockRequest.createRequest(options);
+        expect(request.mySampleProp).to.equal('la LA LA');
+      });
+
     });
 
   });


### PR DESCRIPTION
This will allow someone to attach other, non standard (ie. not `method`, `cookies`, etc) properties to the mock request object. This is useful I think when you need to access a custom object within `request`, like for example `request.user` or something along those lines.