### PR TITLE
Make mockRequest.param work more like express

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -150,7 +150,7 @@ function createRequest(options) {
      *   - req.body
      *   - req.query
      */
-    mockRequest.param = function(parameterName) {
+    mockRequest.param = function(parameterName, defaultValue) {
         if (mockRequest.params[parameterName]) {
             return mockRequest.params[parameterName];
         } else if (mockRequest.body[parameterName]) {
@@ -158,7 +158,7 @@ function createRequest(options) {
         } else if (mockRequest.query[parameterName]) {
             return mockRequest.query[parameterName];
         }
-        return null;
+        return defaultValue;
     };
 
     /**

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -383,6 +383,18 @@ describe('mockRequest', function() {
       expect(request.header('key')).to.not.exist;
     });
 
+    it('should return defaultValue, when not found in params/body/query', function() {
+      request = mockRequest.createRequest();
+      expect(request.get('key')).to.not.exist;
+      expect(request.param('key', 'defaultValue')).to.equal('defaultValue');
+    });
+
+    it('should return undefined, when not found in params/body/query', function() {
+      request = mockRequest.createRequest();
+      expect(request.get('key')).to.not.exist;
+      expect(request.param('key')).to.be.undefined;
+    });
+
   });
 
   describe('helper functions', function() {


### PR DESCRIPTION
1. Use a defaultValue param when provided
2. Return undefined when not found, instead of null

See the implementation of express's param function at https://github.com/strongloop/express/blob/master/lib/request.js#L216