### PR TITLE
Fire 'end' event on response.redirect

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -423,6 +423,7 @@ function createResponse(options) {
 
         }
 
+        mockResponse.emit('end');
     };
 
     /**


### PR DESCRIPTION
I'm using the response 'end' event to make sure my middleware tests complete, but in the redirect case, no 'end' event is fired.