### PR TITLE
Make mockRequest an event emitter.

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -31,6 +31,7 @@
 
 var url = require('url');
 var typeis = require('type-is');
+var events = require('events');
 
 var standardRequestOptions = [
   'method', 'url', 'originalUrl', 'path', 'params', 'session', 'cookies', 'headers', 'body', 'query', 'files'
@@ -52,7 +53,7 @@ function createRequest(options) {
 
     // creat mockRequest
 
-    var mockRequest = {};
+    var mockRequest = Object.create(events.EventEmitter.prototype);
 
     mockRequest.method = (options.method) ? options.method : 'GET';
     mockRequest.url = options.url || options.path || '';

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -22,6 +22,12 @@ describe('mockRequest', function() {
         request = mockRequest.createRequest();
       });
 
+      it('should have event emitter prototype functions', function () {
+        expect(request.on).to.be.a('function');
+        expect(request.once).to.be.a('function');
+        expect(request.emit).to.be.a('function');
+      });
+
       it('should return an object', function() {
         expect(request).to.be.an('object');
       });


### PR DESCRIPTION
Adds basic event emitter functionality to the mock request objects. Might not meet all expectations as per issue #17 so let me know if it's too rudimentary :smile: 