### PR TITLE
fixed issue with req.param not returning when falsy

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -163,11 +163,11 @@ function createRequest(options) {
      *   - req.query
      */
     mockRequest.param = function(parameterName, defaultValue) {
-        if (mockRequest.params[parameterName]) {
+        if (null != mockRequest.params[parameterName]) {
             return mockRequest.params[parameterName];
-        } else if (mockRequest.body[parameterName]) {
+        } else if (null != mockRequest.body[parameterName]) {
             return mockRequest.body[parameterName];
-        } else if (mockRequest.query[parameterName]) {
+        } else if (null != mockRequest.query[parameterName]) {
             return mockRequest.query[parameterName];
         }
         return defaultValue;

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -163,11 +163,11 @@ function createRequest(options) {
      *   - req.query
      */
     mockRequest.param = function(parameterName, defaultValue) {
-        if (null != mockRequest.params[parameterName]) {
+        if (mockRequest.params.hasOwnProperty(parameterName)) {
             return mockRequest.params[parameterName];
-        } else if (null != mockRequest.body[parameterName]) {
+        } else if (mockRequest.body.hasOwnProperty(parameterName)) {
             return mockRequest.body[parameterName];
-        } else if (null != mockRequest.query[parameterName]) {
+        } else if (mockRequest.query.hasOwnProperty(parameterName)) {
             return mockRequest.query[parameterName];
         }
         return defaultValue;

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -370,6 +370,17 @@ describe('mockRequest', function() {
       expect(request.param('key')).to.equal('value');
     });
 
+    it('should return falsy param, when found in params', function() {
+      var options = {
+        params: {
+          key: 0
+        }
+      };
+
+      request = mockRequest.createRequest(options);
+      expect(request.param('key')).to.equal(0);
+    });
+
     it('should return param, when found in body', function() {
       var options = {
         body: {
@@ -381,6 +392,17 @@ describe('mockRequest', function() {
       expect(request.param('key')).to.equal('value');
     });
 
+    it('should return falsy param, when found in body', function() {
+      var options = {
+        body: {
+          key: 0
+        }
+      };
+
+      request = mockRequest.createRequest(options);
+      expect(request.param('key')).to.equal(0);
+    });
+
     it('should return param, when found in query', function() {
       var options = {
         query: {
@@ -390,6 +412,17 @@ describe('mockRequest', function() {
 
       request = mockRequest.createRequest(options);
       expect(request.param('key')).to.equal('value');
+    });
+
+    it('should return falsy param, when found in query', function() {
+      var options = {
+        query: {
+          key: 0
+        }
+      };
+
+      request = mockRequest.createRequest(options);
+      expect(request.param('key')).to.equal(0);
     });
 
     it('should not return param, when not found in params/body/query', function() {


### PR DESCRIPTION
req.param('key') was returning undefined when the actual underlying param was falsy. This was down to the way the check was made for the key. This pull request includes specs to assert the correct value is returned across params, body and query.