### PR TITLE
Make response.headersSent work like node

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -62,6 +62,7 @@ function createResponse(options) {
     mockResponse.statusCode = 200;
     mockResponse.statusMessage = 'OK';
     mockResponse.cookies = {};
+    mockResponse.headersSent = false;
 
     mockResponse.cookie = function(name, value, opt) {
 
@@ -98,6 +99,16 @@ function createResponse(options) {
             throw 'The end() method has already been called.';
         }
 
+        if (mockResponse.headersSent) {
+            // Node docs: "This method must only be called once on a message"
+            // but it doesn't error if you do call it after first chunk of body is sent
+            // so we shouldn't throw here either (although it's a bug in the code).
+            // We return without updating since in real life it's just possible the double call didn't
+            // completely corrupt the response (for example not using chunked encoding due to HTTP/1.0 client)
+            // and in this case the client will see the _original_ headers.
+            return
+        }
+
         mockResponse.statusCode = statusCode;
 
         // resolve statusMessage and headers as optional
@@ -119,8 +130,10 @@ function createResponse(options) {
     };
 
     /**
-     *  The 'send' function from node's HTTP API that returns data
+     *  The 'send' function from restify's Response API that returns data
      *  to the client. Can be called multiple times.
+     *
+     *  @see http://mcavage.me/node-restify/#response-api
      *
      * @param data The data to return. Must be a string.
      */
@@ -189,6 +202,8 @@ function createResponse(options) {
                 break;
 
         }
+
+        mockResponse.headersSent = true;
 
         mockResponse.emit('send');
         mockResponse.emit('end');
@@ -329,6 +344,8 @@ function createResponse(options) {
 
     mockResponse.write = function(data, encoding) {
 
+        mockResponse.headersSent = true;
+
         _data += data;
 
         if (encoding) {
@@ -350,6 +367,8 @@ function createResponse(options) {
      *  encoding - Optional encoding value.
      */
     mockResponse.end = function(data, encoding) {
+
+        mockResponse.headersSent = true;
 
         _endCalled = true;
 

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -106,7 +106,7 @@ function createResponse(options) {
             // We return without updating since in real life it's just possible the double call didn't
             // completely corrupt the response (for example not using chunked encoding due to HTTP/1.0 client)
             // and in this case the client will see the _original_ headers.
-            return
+            return;
         }
 
         mockResponse.statusCode = statusCode;

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -594,6 +594,21 @@ describe('mockResponse', function() {
         expect(response._getHeaders()).to.deep.equal(headers);
       });
 
+      it('updates the headersSent property of the response', function() {
+        var headers = { 'x-header': 'test llama' };
+        response.writeHead(400, headers);
+        // headers are only sent by node with first body byte
+        expect(response.headersSent).to.equal(false);
+        response.write("foo");
+        expect(response.headersSent).to.equal(true);
+        // further updates to headers shouldn't really be reflected in mock headers
+        // since these would be transmitted as part of the body (probably breaking chunked encoding)
+        // in real life.
+        response.writeHead(500, {'x-header': 'llama party'});
+        // Should still see same as before
+        expect(response._getHeaders()).to.deep.equal(headers);
+      });
+
       it('works with statusMessage and headers as optional', function() {
         response.writeHead(400);
         expect(response.statusCode).to.equal(400);

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -599,7 +599,7 @@ describe('mockResponse', function() {
         response.writeHead(400, headers);
         // headers are only sent by node with first body byte
         expect(response.headersSent).to.equal(false);
-        response.write("foo");
+        response.write('foo');
         expect(response.headersSent).to.equal(true);
         // further updates to headers shouldn't really be reflected in mock headers
         // since these would be transmitted as part of the body (probably breaking chunked encoding)


### PR DESCRIPTION
See issue in #89 for details.

Also note that `response.send` is _not_ part of Node's `http` as the comment suggested and is actually mocking a `restify` response object method. I updated the comment to be less confusing but I didn't go further to move it around in test suite etc.

Let me know if you'd prefer I either leave the comment or refactor further (in which case I'll leave it for a separate PR).