### PR TITLE
Fix the behavior of `mockResponse.writeHead`

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -110,10 +110,11 @@ function createResponse(options) {
             mockResponse.statusMessage = statusMessage;
         }
 
-        // Note: Not sure if the headers given in this function
-        //       overwrite any headers specified earlier.
+        // The headers specified earlier (been set with `mockResponse.setHeader`)
+        // should not be overwritten but be merged with the headers
+        // passed into `mockResponse.writeHead`.
         if (headers) {
-            mockResponse._headers = headers;
+            mockResponse._headers = Object.assign(mockResponse._headers, headers);
         }
 
     };

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -29,6 +29,7 @@ var WritableStream = require('./mockWritableStream');
 var EventEmitter = require('./mockEventEmitter');
 var mime = require('mime');
 var http = require('./node/http');
+var _assign = require('lodash.assign');
 
 function createResponse(options) {
 
@@ -114,7 +115,7 @@ function createResponse(options) {
         // should not be overwritten but be merged with the headers
         // passed into `mockResponse.writeHead`.
         if (headers) {
-            mockResponse._headers = Object.assign(mockResponse._headers, headers);
+            mockResponse._headers = _assign(mockResponse._headers, headers);
         }
 
     };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
+    "lodash.assign": "^4.0.6",
     "mime": "^1.3.4",
     "type-is": "^1.6.4"
   },

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -626,6 +626,12 @@ describe('mockResponse', function() {
         expect(response.writeHead.bind(response, 200)).to.throw('The end() method has already been called');
       });
 
+      it('merges the given headers with the ones specified earlier (set with `setHeader`)', function() {
+        response.setHeader('Access-Control-Allow-Origin', '*');
+        response.writeHead(200, {'Access-Control-Max-Age': '86400'});
+        expect(response._getHeaders()).to.contain.all.keys({'Access-Control-Allow-Origin': '*', 'Access-Control-Max-Age': '86400'});
+      });
+
     });
 
   });


### PR DESCRIPTION
The headers specified earlier (been set with `mockResponse.setHeader`) should not be overwritten but be merged with the headers passed into `mockResponse.writeHead`.