### PR TITLE
write method invocation into json method

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -258,14 +258,14 @@ function createResponse(options) {
             if (typeof a === 'number') {
                 mockResponse.statusCode = a;
             } else {
-                _data += JSON.stringify(a);
+                mockResponse.write(JSON.stringify(a), 'utf8');
             }
         }
         if (b) {
             if (typeof b === 'number') {
                 mockResponse.statusCode = b;
             } else {
-                _data += JSON.stringify(b);
+                mockResponse.write(JSON.stringify(b), 'utf8');
             }
         }
 

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -538,6 +538,18 @@ describe('mockResponse', function() {
         expect(response.emit).to.have.been.calledWith('end');
       });
 
+      // reference : https://github.com/howardabrams/node-mocks-http/pull/98
+      it('should call .write()', function() {
+        var originalWrite = response.write.bind(response);
+        var hackedContent = JSON.stringify({foo: 'bar'});
+        response.write = function(data, encoding) {
+          console.log('data :', data);
+          return originalWrite(hackedContent, encoding);
+        };
+        response.json({hello: 'world'});
+        expect(response._getData()).to.eql(hackedContent);
+      });
+
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.jsonp()
@@ -1042,5 +1054,6 @@ describe('mockResponse', function() {
     });
 
   });
+
 
 });


### PR DESCRIPTION
Problem encountered : the write method is never called by json method of responseMock, and sometimes we need to override the write method of a response object.
Solution : simply call write method from json method of responseMock instead of directly populate _data into json method.
