### PR TITLE
Adds .format to the response object. Closes #94.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ option | description | default value
 ------ | ----------- | -------------
 `eventEmitter` | event emitter used by `response` object | `mockEventEmitter`
 `writableStream`  | writable stream used by `response` object | `mockWritableStream`
+`req` | Request object being responded to | null
 
 > NOTE: The out-of-the-box mock event emitter included with `node-mocks-http` is
 not a functional event emitter and as such does not actually emit events. If you
@@ -132,6 +133,15 @@ var res = httpMocks.createResponse({
   });
 // ...
 ```
+
+### .createMocks()
+
+```js
+httpMocks.createMocks(reqOptions, resOptions)
+```
+
+Merges `createRequest` and `createResponse`. Passes given options object to each
+constructor.
 
 ## Design Decisions
 

--- a/lib/http-mock.js
+++ b/lib/http-mock.js
@@ -10,5 +10,23 @@
 var request = require('./mockRequest');
 var response = require('./mockResponse');
 
+/**
+ * Creates linked req and res objects. Enables using methods that require both
+ * objects to interact, for example res.format.
+ *
+ * @param  {Object} reqOpts Options for req creation, see
+ *                          @mockRequest.createRequest
+ * @param  {Object} resOpts Options for res creation, see
+ *                          @mockResponse.createResponse
+ * @return {Object}         Object with both mocks: { req, res }
+ */
+var createRequestResponse = function (reqOpts, resOpts) {
+    var req = request.createRequest(reqOpts);
+    var res = response.createResponse(Object.assign({}, resOpts, { req: req }));
+
+    return { req: req, res: res };
+};
+
 exports.createRequest = request.createRequest;
 exports.createResponse = response.createResponse;
+exports.createMocks = createRequestResponse;

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -31,6 +31,7 @@
 
 var url = require('url');
 var typeis = require('type-is');
+var accepts = require('accepts');
 var events = require('events');
 
 var standardRequestOptions = [
@@ -76,6 +77,17 @@ function createRequest(options) {
     //parse query string from url to object
     if (Object.keys(mockRequest.query).length === 0) {
         mockRequest.query = require('querystring').parse(mockRequest.url.split('?')[1]);
+
+        if (!mockRequest.query.hasOwnProperty) {
+            Object.defineProperty(
+                mockRequest.query,
+                'hasOwnProperty',
+                {
+                    enumerable: false,
+                    value: Object.hasOwnProperty.bind(mockRequest.query)
+                }
+            );
+        }
     }
 
     // attach any other provided objects into the request for more advanced testing
@@ -151,6 +163,32 @@ function createRequest(options) {
             types = [].slice.call(arguments);
         }
         return typeis(mockRequest, types);
+    };
+
+    /**
+     * Function: accepts
+     *
+     *   Checks for matching content types in the Accept header.
+     *
+     * Examples:
+     *
+     *     mockRequest.headers['accept'] = 'application/json'
+     *
+     *     mockRequest.accepts('json');
+     *     // => 'json'
+     *
+     *     mockRequest.accepts('html');
+     *     // => false
+     *
+     *     mockRequest.accepts(['html', 'json']);
+     *     // => 'json'
+     *
+     * @param  {String|String[]} types Mime type(s) to check against
+     * @return {String|false}          Matching type or false if no match.
+     */
+    mockRequest.accepts = function(types) {
+        var Accepts = accepts(mockRequest);
+        return Accepts.type(types);
     };
 
     /**
@@ -336,7 +374,6 @@ function createRequest(options) {
     };
 
     return mockRequest;
-
 }
 
 module.exports.createRequest = createRequest;

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -54,6 +54,7 @@ function createResponse(options) {
     var writableStream = new WritableStream();
     var eventEmitter = new EventEmitter();
 
+    var mockRequest = options.req;
     // create mockResponse
 
     var mockResponse = {};
@@ -328,7 +329,7 @@ function createResponse(options) {
      * @return {ServerResponse} for chaining
      * @api public
      */
-    mockResponse.contentType = mockResponse.type = function(type){
+    mockResponse.contentType = mockResponse.type = function(type) {
         return mockResponse.set('Content-Type', type.indexOf('/') >= 0 ? type : mime.lookup(type));
     };
 
@@ -563,6 +564,42 @@ function createResponse(options) {
         mockResponse.emit('render');
         mockResponse.emit('end');
 
+    };
+
+    /**
+     * Chooses the correct response function from the given supported types.
+     * This method requires that the mockResponse object be initialized with a
+     * mockRequest object reference, otherwise it will throw. @see createMocks.
+     *
+     * @param  {Object} supported Object with formats to handler functions.
+     * @return {Object}           Whatever handler function returns.
+     */
+    mockResponse.format = function(supported) {
+        supported = supported || {};
+        var types = Object.keys(supported);
+
+        if (types.length === 0) {
+            return mockResponse.sendStatus(406);
+        }
+
+        if (!mockRequest) {
+            throw new Error(
+                'Request object unavailable. Use createMocks or pass in a ' +
+                'request object in createResponse to use format.'
+            );
+        }
+
+        var accepted = mockRequest.accepts(types);
+
+        if (accepted) {
+            return supported[accepted]();
+        }
+
+        if (supported.default) {
+            return supported.default();
+        }
+
+        return mockResponse.sendStatus(406);
     };
 
     // WritableStream.writable is not a function

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
+    "accepts": "^1.3.3",
     "lodash.assign": "^4.0.6",
     "mime": "^1.3.4",
     "type-is": "^1.6.4"

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -352,6 +352,27 @@ describe('mockRequest', function() {
 
   });
 
+  describe('.accepts()', function() {
+    var request;
+
+    beforeEach(function() {
+      request = mockRequest.createRequest({ headers: { accept: 'text/html' }});
+    });
+
+    it('returns type if the same as Accept header', function() {
+      expect(request.accepts('text/html')).to.equal('text/html');
+      expect(request.accepts('html')).to.equal('html');
+    });
+
+    it('returns the first matching type of an array of types', function() {
+      expect(request.accepts(['json', 'html'])).to.equal('html');
+    });
+
+    it('returns false when types dont match', function() {
+      expect(request.accepts(['json', 'xml'])).to.equal(false);
+    });
+  });
+
   describe('.param()', function() {
     var request;
 
@@ -442,7 +463,6 @@ describe('mockRequest', function() {
       expect(request.get('key')).to.not.exist;
       expect(request.param('key')).to.be.undefined;
     });
-
   });
 
   describe('helper functions', function() {


### PR DESCRIPTION
Enables a reference in the mockResponse to mockRequest, making possible the implementation [`res.format`](http://expressjs.com/en/api.html#res.format).

Adds a new API method, `createMocks` that instances and creates both mock objects with already the correct reference.