### PR TITLE
Added the EventEmitter prependListener support to the response mock

### DIFF
--- a/lib/mockEventEmitter.js
+++ b/lib/mockEventEmitter.js
@@ -15,6 +15,7 @@ EventEmitter.prototype.removeAllListeners = function () {};
 EventEmitter.prototype.setMaxListeners = function () {};
 EventEmitter.prototype.listeners = function () {};
 EventEmitter.prototype.emit = function () {};
+EventEmitter.prototype.prependListener = function () {};
 // EventEmitter.prototype.emit = function(event, [arg1], [arg2], [...]){}
 
 module.exports = EventEmitter;

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -651,6 +651,10 @@ function createResponse(options) {
         return eventEmitter.emit.apply(this, arguments);
     };
 
+    mockResponse.prependListener = function() {
+      return eventEmitter.prependListener.apply(this, arguments);
+    };
+
     //This mock object stores some state as well
     //as some test-analysis functions:
 

--- a/test/lib/mockEventEmitter.spec.js
+++ b/test/lib/mockEventEmitter.spec.js
@@ -45,6 +45,9 @@ describe('mockEventEmitter', function() {
 
     expect(mockEventEmitter).to.have.property('emit');
     expect(mockEventEmitter.emit).to.be.a('function');
+
+    expect(mockEventEmitter).to.have.property('prependListener');
+    expect(mockEventEmitter.prependListener).to.be.a('function');
   });
 
   it('should return undefined when methods called', function() {
@@ -56,6 +59,8 @@ describe('mockEventEmitter', function() {
     expect(mockEventEmitter.setMaxListeners()).to.be.undefined;
     expect(mockEventEmitter.listeners()).to.be.undefined;
     expect(mockEventEmitter.emit()).to.be.undefined;
+    expect(mockEventEmitter.prependListener()).to.be.undefined;
+
   });
 
 });

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -128,6 +128,9 @@ describe('mockResponse', function() {
 
       expect(response).to.have.property('emit');
       expect(response.emit).to.be.a('function');
+
+      expect(response).to.have.property('prependListener');
+      expect(response.prependListener).to.be.a('function');
     });
 
     it('should expose heler methods', function() {
@@ -882,6 +885,12 @@ describe('mockResponse', function() {
     describe('.emit()', function() {
 
       it('should inherit from Node EventEmitter.emit()');
+
+    });
+
+    describe('.prependListener()', function() {
+
+      it('should inherit from Node EventEmitter.prependListener()');
 
     });
 


### PR DESCRIPTION
Hi @howardabrams 

I encountered an issue when using the node-mocks-http and the https://github.com/pillarjs/send library. See below the error it was throwing.

```
Uncaught TypeError: emitter.prependListener is not a function
      at prependListener (_stream_readable.js:19:20)
      at ReadStream.Readable.pipe (_stream_readable.js:582:3)
      at SendStream.stream (node_modules/send/index.js:746:10)
      at SendStream.send (node_modules/send/index.js:655:8)
      at onstat (node_modules/send/index.js:677:10)
      at FSReqWrap.oncomplete (node_modules/mock-fs/node/fs-6.3.0.js:81:15)
      at node_modules/mock-fs/lib/binding.js:39:9
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```

I fixed that by adding support for the EventEmitter prependListener method on the node-mock-http.

Could you please review my change?

Cheers
