### PR TITLE
Auto publish and git-push after version bumping

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "sinon-chai": "^2.7.0"
   },
   "scripts": {
-    "test": "gulp spec"
+    "test": "gulp spec",
+    "postversion": "npm publish && git push --follow-tags"
   }
 }


### PR DESCRIPTION
As described [here](https://github.com/howardabrams/node-mocks-http/issues/105#issuecomment-247001007)

FYI, you can just do npm version <patch|minor|major> to bump versions when doing a release. That will bump the version in package.json, do a git commit and git tag automatically.

And with this PR, it will also automatically be published to npm and pushed to github.