### PR TITLE
EventEmitter for request/response

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -32,7 +32,7 @@
 var url = require('url');
 var typeis = require('type-is');
 var accepts = require('accepts');
-var events = require('events');
+var EventEmitter = require('events').EventEmitter;
 
 var standardRequestOptions = [
   'method', 'url', 'originalUrl', 'path', 'params', 'session', 'cookies', 'headers', 'body', 'query', 'files'
@@ -52,9 +52,13 @@ function createRequest(options) {
         options = {};
     }
 
-    // creat mockRequest
+    if (options.eventEmitter) {
+        EventEmitter = options.eventEmitter;
+    }
 
-    var mockRequest = Object.create(events.EventEmitter.prototype);
+    // create mockRequest
+    var mockRequest = Object.create(EventEmitter.prototype);
+    EventEmitter.call(mockRequest);
 
     mockRequest.method = (options.method) ? options.method : 'GET';
     mockRequest.url = options.url || options.path || '';

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -52,12 +52,12 @@ function createResponse(options) {
         EventEmitter = options.eventEmitter;
     }
     var writableStream = new WritableStream();
-    var eventEmitter = new EventEmitter();
 
     var mockRequest = options.req;
     // create mockResponse
 
-    var mockResponse = {};
+    var mockResponse = Object.create(EventEmitter.prototype);
+    EventEmitter.call(mockResponse);
 
     mockResponse._headers = {};
 
@@ -618,42 +618,6 @@ function createResponse(options) {
 
     mockResponse.destroySoon = function() {
         return writableStream.destroySoon.apply(this, arguments);
-    };
-
-    mockResponse.addListener = function() {
-        return eventEmitter.addListener.apply(this, arguments);
-    };
-
-    mockResponse.on = function() {
-        return eventEmitter.on.apply(this, arguments);
-    };
-
-    mockResponse.once = function() {
-        return eventEmitter.once.apply(this, arguments);
-    };
-
-    mockResponse.removeListener = function() {
-        return eventEmitter.removeListener.apply(this, arguments);
-    };
-
-    mockResponse.removeAllListeners = function() {
-        return eventEmitter.removeAllListeners.apply(this, arguments);
-    };
-
-    mockResponse.setMaxListeners = function() {
-        return eventEmitter.setMaxListeners.apply(this, arguments);
-    };
-
-    mockResponse.listeners = function() {
-        return eventEmitter.listeners.apply(this, arguments);
-    };
-
-    mockResponse.emit = function() {
-        return eventEmitter.emit.apply(this, arguments);
-    };
-
-    mockResponse.prependListener = function() {
-        return eventEmitter.prependListener.apply(this, arguments);
     };
 
     //This mock object stores some state as well


### PR DESCRIPTION
I'm using these mocks to trigger 'actual' http pipelines in https://github.com/dougmoscrop/serverless-http

Things work pretty good but I had to make these changes so that various things like piping through inflate worked. The two different mock objects behave the same way now