### PR TITLE
Preparatory work for upgrading to v1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4.2"
+  - "6.9"
+  - "7.4"
 
 notifications:
   email:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+v 1.6.0
+-------
+
+  - Dropping support for Node's "0" version, but will continue to support v4.
+  - Verifying our builds with v6 (latest stable) as well as current work (v7)
+  - Removing dependency on lodash and other bug fixes
+
 v 1.5.4
 -------
 


### PR DESCRIPTION
No longer building version of our test suite with version 0.12 (now that
it has been end-of-life for over a year), but will also start checking
with the latest version of Node.