### PR TITLE
Publish only required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "spec": "gulp spec",
     "test": "gulp test",
     "postversion": "npm publish && git push --follow-tags"
-  }
+  },
+  "files":[
+    "lib"
+  ]
 }


### PR DESCRIPTION
This PR removes unnecessary files (test, examples) when publishing to npm. Please see the npm docs on the [files key](https://docs.npmjs.com/files/package.json#files) in `package.json`.

**To see how this will be packaged without publishing, run:**
```
npm pack
# produces node-mocks-http-1.6.2.tgz
```

**Files that will be published with this PR:**
```
./HISTORY.md
./lib
./lib/express
./lib/express/mock-application.js
./lib/express/mock-express.js
./lib/express/mock-request.js
./lib/express/utils
./lib/express/utils/define-getter.js
./lib/http-mock.js
./lib/index.d.ts
./lib/mockEventEmitter.js
./lib/mockRequest.js
./lib/mockResponse.js
./lib/mockWritableStream.js
./lib/node
./lib/node/_http_incoming.js
./lib/node/_http_server.js
./lib/node/http.js
./LICENSE
./package.json
./README.md
```

Thanks for the awesome library!