### PR TITLE
Make Query type definition more flexible

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -30,7 +30,7 @@ declare module 'node-mocks-http' {
     }
 
     export interface Body {
-        [key: string]: string;
+        [key: string]: any;
     }
 
     export interface RequestOptions {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 declare module 'node-mocks-http' {
 
     export type RequestMethod =
-        'GET' | 'HEAD'| 'POST' | 'PUT' | 'DELETE' | 'TRACE' | 'CONNECT';
+        'CONNECT' | 'DELETE' | 'GET' | 'HEAD' | 'OPTIONS' | 'PATCH' | 'POST' | 'PUT' | 'TRACE';
 
     export interface Params {
         [key: string]: any;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -22,7 +22,7 @@ declare module 'node-mocks-http' {
     }
 
     export interface Query {
-        [key: string]: string;
+        [key: string]: any;
     }
 
     export interface Files {


### PR DESCRIPTION
The type definitions file exposed an interface for `Query` that was overly rigid. It is possible when forming a request to describe query parameters that are not simple key-value pairs, but are in fact more structured data.

Consider, for example, a GET request complying to [JSON API's specification for pagination:](http://jsonapi.org/format/#fetching-pagination)

`https://my-api-server.com/api/v1/posts?page[number]=4&page[size]=20`

This would be parsed to something like this:

```javascript
{
  page: {
    number: 4,
    size: 20,
  }
}
```

For this reason, it is not reasonable to limit the key-value pairs assignable to the `Query` interface to be only strings. Instead, we can use the `any` key, to allow for more structured query params.

Similarly, it is important to allow the `RequestOptions.body` to be of a more flexible type. It is possible that the request body might not be of type `string`, but might in fact be an `Object`.

Finally, this PR adds missing HTTP methods and alphabetizes them.