### PR TITLE
upgrade fresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "accepts": "^1.3.3",
     "depd": "^1.1.0",
-    "fresh": "^0.3.0",
+    "fresh": "^0.5.2",
     "merge-descriptors": "^1.0.1",
     "methods": "^1.1.2",
     "mime": "^1.3.4",


### PR DESCRIPTION
Hello, There's a [node security advisory for fresh](https://nodesecurity.io/advisories/526).  Upgrading to 0.5.2 will resolve this vulnerability, and stop nsp from yelling about it.  Your tests pass with the 0.5.2 upgrade, and I glanced at your use of fresh and the upgrade seems trivial for your use case. :)