### PR TITLE
Added baseUrl property

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ option | description | default value
 `method`| request HTTP method | 'GET'
 `url` | request URL | ''
 `originalUrl` | request original URL | `url`
+`baseUrl` | request base URL | `url`
 `path` | request path | ''
 `params` | object hash with params | {}
 `session` | object hash with session values | `undefined`

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -37,6 +37,7 @@ declare module 'node-mocks-http' {
         method?: RequestMethod;
         url?: string;
         originalUrl?: string;
+        baseUrl?: string;
         path?: string;
         params?: Params;
         session?: Session;

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -25,6 +25,7 @@
  *   method      - The method value, see <mockRequest._setMethod>
  *   url         - The url value, see <mockRequest._setURL>
  *   originalUrl - The originalUrl value, see <mockRequest._setOriginalUrl>
+ *   baseUrl     - The baseUrl value, see <mockRequest._setBaseUrl>
  *   params      - The parameters, see <mockRequest._setParam>
  *   body        - The body values, , see <mockRequest._setBody>
  */
@@ -35,7 +36,7 @@ var accepts = require('accepts');
 var EventEmitter = require('events').EventEmitter;
 
 var standardRequestOptions = [
-    'method', 'url', 'originalUrl', 'path', 'params', 'session', 'cookies', 'headers', 'body', 'query', 'files'
+    'method', 'url', 'originalUrl', 'baseUrl', 'path', 'params', 'session', 'cookies', 'headers', 'body', 'query', 'files'
 ];
 
 function convertKeysToLowerCase(map) {
@@ -63,6 +64,7 @@ function createRequest(options) {
     mockRequest.method = options.method ? options.method : 'GET';
     mockRequest.url = options.url || options.path || '';
     mockRequest.originalUrl = options.originalUrl || mockRequest.url;
+    mockRequest.baseUrl = options.baseUrl || mockRequest.url;
     mockRequest.path = options.path ||
         ((options.url ? url.parse(options.url).pathname : ''));
     mockRequest.params = options.params ? options.params : {};
@@ -318,6 +320,23 @@ function createRequest(options) {
      */
     mockRequest._setURL = function(value) {
         mockRequest.url = value;
+    };
+
+    /**
+     * Function: _setBaseUrl
+     *
+     *    Sets the URL value that the client gets when the called the 'baseUrl'
+     *    property.
+     *
+     * Parameters:
+     *
+     *   value - The request base path, e.g. /my-route
+     *
+     * Note: We don't validate the string. We just return it. Typically, these
+     * do not include hostname, port or that part of the URL.
+     */
+    mockRequest._setBaseUrl = function(value) {
+        mockRequest.baseUrl = value;
     };
 
     /**

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -47,6 +47,7 @@ describe('mockRequest', function() {
         expect(request.method).to.equal('GET');
         expect(request.url).to.equal('');
         expect(request.originalUrl).to.equal(request.url);
+        expect(request.baseUrl).to.equal(request.url);
         expect(request.path).to.equal('');
         expect(request.params).to.deep.equal({});
         expect(request.session).to.not.exist;
@@ -83,6 +84,7 @@ describe('mockRequest', function() {
         request = mockRequest.createRequest(options);
         expect(request.url).to.equal(options.url);
         expect(request.originalUrl).to.equal(options.url);
+        expect(request.baseUrl).to.equal(options.url);
       });
 
       it('should set .url automatically', function() {
@@ -94,6 +96,15 @@ describe('mockRequest', function() {
 
         request = mockRequest.createRequest(options);
         expect(request.url).to.equal(expectedUrl);
+      });
+
+      it('should set .baseUrl to options.baseUrl', function() {
+        var options = {
+          baseUrl: '/this'
+        };
+
+        request = mockRequest.createRequest(options);
+        expect(request.baseUrl).to.equal(options.baseUrl);
       });
 
       it('should set .originalUrl to options.originalUrl', function() {
@@ -612,6 +623,21 @@ describe('mockRequest', function() {
       it('should unset url, when called with no arguments', function() {
         request._setURL();
         expect(request.url).to.not.exist;
+      });
+
+    });
+
+    describe('._setBaseUrl()', function() {
+
+      it('should set baseUrl, when called with value', function() {
+        var value = '/path';
+        request._setBaseUrl(value);
+        expect(request.baseUrl).to.equal(value);
+      });
+
+      it('should unset baseUrl, when called with no arguments', function() {
+        request._setBaseUrl();
+        expect(request.baseUrl).to.not.exist;
       });
 
     });


### PR DESCRIPTION
Added the baseUrl property to the request object.

http://expressjs.com/en/api.html#req.baseUrl

Included test cases similar to originalUrl. Similarly to request.originalUrl, request.baseUrl does not provide validation.