### PR TITLE
add missing property 'cookies' to MockResponse type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Request, Response, CookieOptions } from 'express';
 
 declare module 'node-mocks-http' {
 
@@ -75,6 +75,11 @@ declare module 'node-mocks-http' {
         req?: any;
     }
 
+    export type ResponseCookie = {
+        value: any;
+        options: CookieOptions;
+    }
+
     export type MockResponse<T extends Response> = T & {
         _isEndCalled: () => boolean;
         _getHeaders: () => Headers;
@@ -87,6 +92,8 @@ declare module 'node-mocks-http' {
         _getRedirectUrl: () => string;
         _getRenderData: () => any;
         _getRenderView: () => string;
+
+        cookies: {[name: string]: ResponseCookie};
     }
 
     export function createRequest<T extends Request = Request>(options?: RequestOptions): MockRequest<T>;


### PR DESCRIPTION
Hi,

The MockResponse-type-definition lacks the "cookies" property. For value and options I re-used the same typings used for express' cookie() function arguments.

I don't understand your pattern when to use "interface" and when to use "type", so I chose "type" do define ResponseCookies, as I personally prefer "type" do describe shapes for ordinary JS objects/dicts.

If you don't like the definition as type-alias, just let me know, and I'll switch it to an interface.