### PR TITLE
mockResponse - add support for Buffer writes, tests

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -40,7 +40,7 @@ function createResponse(options) {
     var _data = '';
     var _buffer = new Buffer(0);
     var _chunks = [];
-    var _size = 0; 
+    var _size = 0;
     var _encoding = options.encoding;
 
     var _redirectUrl = '';
@@ -676,8 +676,25 @@ function createResponse(options) {
         return _data;
     };
 
+    /**
+     * Function: _getBuffer
+     *
+     *  The buffer containing data to be sent to the user.
+     *  Non-empty if Buffers were given in calls to write() and end()
+     */
     mockResponse._getBuffer = function() {
         return _buffer;
+    };
+
+
+    /**
+     * Function: _getChunks
+     *
+     *  The buffer containing data to be sent to the user.
+     *  Non-empty if Buffers were given in calls to write() and end()
+     */
+    mockResponse._getChunks = function() {
+        return _chunks;
     };
 
     /**

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -38,7 +38,7 @@ function createResponse(options) {
 
     var _endCalled = false;
     var _data = '';
-    var _buffer = null;
+    var _buffer = new Buffer(0);
     var _chunks = [];
     var _size = 0; 
     var _encoding = options.encoding;

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -510,6 +510,10 @@ function createResponse(options) {
         _encoding = encoding;
     };
 
+    mockResponse.getEncoding = function() {
+        return _encoding;
+    };
+
     /**
      * Function: redirect
      *

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -38,6 +38,9 @@ function createResponse(options) {
 
     var _endCalled = false;
     var _data = '';
+    var _buffer = null;
+    var _chunks = [];
+    var _size = 0; 
     var _encoding = options.encoding;
 
     var _redirectUrl = '';
@@ -355,7 +358,12 @@ function createResponse(options) {
 
         mockResponse.headersSent = true;
 
-        _data += data;
+        if (data instanceof Buffer) {
+            _chunks.push(data);
+            _size += data.length;
+        } else {
+            _data += data;
+        }
 
         if (encoding) {
             _encoding = encoding;
@@ -387,7 +395,28 @@ function createResponse(options) {
         _endCalled = true;
 
         if (data) {
-            _data += data;
+            if (data instanceof Buffer) {
+                _chunks.push(data);
+                _size += data.length;
+            } else {
+                _data += data;
+            }
+        }
+
+        if (_chunks.length) {
+            switch (_chunks.length) {
+                case 1:
+                    _buffer = _chunks[0];
+                    break;
+                default:
+                    _buffer = new Buffer(_size);
+                    for (var i = 0, pos = 0, l = _chunks.length; i < l; i++) {
+                        var chunk = _chunks[i];
+                        chunk.copy(_buffer, pos);
+                        pos += chunk.length;
+                    }
+                    break;
+            }
         }
 
         if (encoding) {
@@ -645,6 +674,10 @@ function createResponse(options) {
      */
     mockResponse._getData = function() {
         return _data;
+    };
+
+    mockResponse._getBuffer = function() {
+        return _buffer;
     };
 
     /**

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -846,6 +846,46 @@ describe('mockResponse', function() {
     });
 
     describe('.write()', function() {
+      var response;
+
+      beforeEach(function() {
+        response = mockResponse.createResponse();
+      });
+
+      it('should accept a string and hold it in _data', function() {
+        var payload1 = 'payload1';
+        var encoding = 'utf8';
+        response.write(payload1, encoding);
+        expect(response._getData()).to.equal(payload1);
+        expect(response.getEncoding()).to.equal(encoding);
+      });
+
+      it('should accept multiple strings and concatenate them in _data', function() {
+        var payload1 = 'payload1';
+        var payload2 = 'payload2';
+        response.write(payload1);
+        response.write(payload2);
+        expect(response._getData()).to.equal(payload1 + payload2);
+      });
+
+      it('should accept a buffer and hold it in _chunks', function() {
+        var payload1 = 'payload1';
+        response.write(new Buffer(payload1));
+        var chunks = response._getChunks();
+        expect(chunks.length).to.eql(1);
+        expect(chunks[0].toString()).to.equal(payload1);
+      });
+
+      it('should accept multiple buffers and hold them in _chunks', function() {
+        var payload1 = 'payload1';
+        var payload2 = 'payload2';
+        response.write(new Buffer(payload1));
+        response.write(new Buffer(payload2));
+        var chunks = response._getChunks();
+        expect(chunks.length).to.eql(2);
+        expect(chunks[0].toString()).to.equal(payload1);
+        expect(chunks[1].toString()).to.equal(payload2);
+      });
 
       it('should inherit from Node OutogingMessage.write()');
 
@@ -871,8 +911,49 @@ describe('mockResponse', function() {
         expect(emits).to.eql(1);
       });
 
+      it('writes to _data if a string is supplied', function() {
+        var payload1 = 'payload1';
+        var encoding = 'utf8';
+        response.end(payload1, encoding);
+        expect(response._getData()).to.equal(payload1);
+        expect(response.getEncoding()).to.equal(encoding);
+      });
+
+      it('writes to _buffer if a Buffer is supplied', function() {
+        var payload1 = 'payload1';
+        response.end(new Buffer(payload1));
+        var buffer = response._getBuffer();
+        expect(buffer.toString()).to.equal(payload1);
+      });
+
       it('should inherit from Node OutogingMessage.end()');
 
+    });
+
+  });
+
+  describe('write() + end() interactions', function() {
+    var response;
+
+    beforeEach(function() {
+      response = mockResponse.createResponse();
+    });
+
+    it('should accept strings through write() and end() and concatenate them in _data', function() {
+      var payload1 = 'payload1';
+      var payload2 = 'payload2';
+      response.write(payload1);
+      response.end(payload2);
+      expect(response._getData()).to.equal(payload1 + payload2);
+    });
+
+    it('should accept buffers through write() and end() and concatenate them in _buffer', function() {
+      var payload1 = 'payload1';
+      var payload2 = 'payload2';
+      response.write(new Buffer(payload1));
+      response.end(new Buffer(payload2));
+      var buffer = response._getBuffer();
+      expect(buffer.toString()).to.equal(payload1 + payload2);
     });
 
   });


### PR DESCRIPTION
From @cpd0101:
* Allow `encoding` to be retrieved via `getEncoding`
* Support the use of Buffers when calling `write`/`end`

From myself:
* Declare a new getter `_getChunks`, for testing purposes
* Add javadoc for  `_getBuffer`
* Add a suite of tests that ensure that calls to `write` and `end` with payloads
result in the correct state of `_data`, `_chunks` and `_buffer`. Ensure that methods
are tested in isolation, using a separate suite for interactions between `write` and `end`

This PR builds on and supersedes #154