### PR TITLE
Send request body/payload to trigger relevant events

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,41 @@ var res = httpMocks.createResponse({
 // ...
 ```
 
+> This is an example to send request body and trigger it's 'data' and 'end' events:
+
+```js
+var httpMocks = require('node-mocks-http');
+var req = httpMocks.createRequest();
+var res = httpMocks.createResponse({
+  eventEmitter: require('events').EventEmitter
+});
+
+// ...
+  it('should do something', function(done) {
+    res.on('end', function() {
+      expect(response._getData()).to.euqal('data sent in request');
+      done();
+    });
+
+    route(req,res);
+
+    req.send('data sent in request');
+  });
+
+  function route(req,res){
+    var data= [];
+    req.on("data", chunk => {
+        data.push(chunk)
+    });
+    req.on("end", () => {
+        data = Buffer.concat(data)
+        res.write(data);
+        res.end();
+    });
+    
+}
+// ...
+
 ### .createMocks()
 
 ```js

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -414,8 +414,6 @@ function createRequest(options) {
             this.emit('data', Buffer.from(JSON.stringify(data)));
         }else if(typeof data === 'string'){
             this.emit('data', Buffer.from(data));
-        }else{
-            throw Error("Unsupported data type to send :" + typeof data)
         }
         this.emit('end');
     };

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -415,8 +415,7 @@ function createRequest(options) {
         }else if(typeof data === 'string'){
             this.emit('data', Buffer.from(data));
         }else{
-            //undefined, null
-            //throw Error("Unsupported data type to send :" + typeof data)
+            throw Error("Unsupported data type to send :" + typeof data)
         }
         this.emit('end');
     };

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -396,6 +396,31 @@ function createRequest(options) {
         mockRequest.body[key] = value;
     };
 
+    
+    /**
+     * Function: send
+     *
+     *    Write data to the request stream which will trigger request's 'data', and 'end' event
+     *
+     * Parameters:
+     *
+     *   data - string, array, object, number, buffer
+     */
+    mockRequest.send = function(data) {
+        
+        if(Buffer.isBuffer(data)){
+            this.emit('data', data);
+        }else if(typeof data === 'object' || typeof data === 'number'){
+            this.emit('data', Buffer.from(JSON.stringify(data)));
+        }else if(typeof data === 'string'){
+            this.emit('data', Buffer.from(data));
+        }else{
+            //undefined, null
+            //throw Error("Unsupported data type to send :" + typeof data)
+        }
+        this.emit('end');
+    };
+    
     return mockRequest;
 }
 

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -694,6 +694,77 @@ describe('mockRequest', function() {
 
     });
 
+    describe('.send()', function() {
+
+      it('should trigger data and end event when string is given', function(done) {
+        var data = [];
+        request.on('data', function(chunk) {
+          data.push(chunk);
+        });
+        request.on('end', function() {
+          data = Buffer.concat(data).toString();
+          expect(data).to.equal('test data');
+          done();
+        });
+        request.send('test data');
+      });
+
+      it('should trigger data and end event when object is given', function(done) {
+        var data = [];
+        var dataTosend = {'key' : 'value'};
+        request.on('data', function(chunk) {
+          data.push(chunk);
+        });
+        request.on('end', function() {
+          data = Buffer.concat(data).toString();
+          expect(JSON.parse(data)).to.deep.equal(dataTosend);
+          done();
+        });
+        request.send(dataTosend);
+      });
+
+      it('should trigger data and end event when number is given', function(done) {
+        var data = [];
+        request.on('data', function(chunk) {
+          data.push(chunk);
+        });
+        request.on('end', function() {
+          data = Buffer.concat(data).toString();
+          expect(data).to.equal('35');
+          done();
+        });
+        request.send(35);
+      });
+
+      it('should trigger data and end event when buffer is given', function(done) {
+        var data = [];
+        var bufferdata = Buffer.from('test data');
+        request.on('data', function(chunk) {
+          data.push(chunk);
+        });
+        request.on('end', function() {
+          data = Buffer.concat(data).toString();
+          expect(data).to.equal('test data');
+          done();
+        });
+        request.send(bufferdata);
+      });
+
+      it('should trigger data and end event when nothing is given', function(done) {
+        var data = [];
+        request.on('data', function(chunk) {
+          data.push(chunk);
+        });
+        request.on('end', function() {
+          data = Buffer.concat(data).toString();
+          expect(data).to.equal('');
+          done();
+        });
+        request.send();
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
#162
Following change will trigger 'data', and 'end' event on request stream when user calls 'send' method.