### PR TITLE
turn mock request into a stream

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -34,6 +34,7 @@ var url = require('url');
 var typeis = require('type-is');
 var accepts = require('accepts');
 var EventEmitter = require('events').EventEmitter;
+var Readable = require('stream').Readable;
 
 var standardRequestOptions = [
     'method', 'url', 'originalUrl', 'baseUrl', 'path', 'params', 'session', 'cookies', 'headers', 'body', 'query', 'files'
@@ -58,7 +59,7 @@ function createRequest(options) {
     }
 
     // create mockRequest
-    var mockRequest = Object.create(EventEmitter.prototype);
+    var mockRequest = new Readable();
     EventEmitter.call(mockRequest);
 
     mockRequest.method = options.method ? options.method : 'GET';

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -32,6 +32,14 @@ describe('mockRequest', function() {
         expect(request).to.be.an('object');
       });
 
+      it('should be an EventEmitter', function() {
+        expect(request).to.be.an.instanceof(require('events').EventEmitter);
+      });
+
+      it('should be a Readable stream', function() {
+        expect(request).to.be.an.instanceof(require('stream').Readable);
+      });
+
       it('should expose Express Request object methods', function() {
         expect(request).to.have.property('get');
         expect(request.get).to.be.a('function');


### PR DESCRIPTION
`http.IncomingMessage` extends `stream.Readable` extends `NodeJS.ReadableStream` extends `NodeJS.EventEmitter`.

a mock request that implements `stream.Readable` (which is-a `events.EventEmitter`) gets us a little closer to `http.IncomingMessage` than `events.EventEmitter` alone.

is there a downside to this approach?