### PR TITLE
Added missing typings for "locals" & created a helper method to get locals

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -73,6 +73,7 @@ declare module 'node-mocks-http' {
         eventEmitter?: any;
         writableStream?: any;
         req?: any;
+        locals?: any;
     }
 
     export type ResponseCookie = {
@@ -84,6 +85,7 @@ declare module 'node-mocks-http' {
         _isEndCalled: () => boolean;
         _getHeaders: () => Headers;
         _getData: () => any;
+        _getLocals: () => any;
         _getStatusCode: () => number;
         _getStatusMessage: () => string;
         _isJSON: () => boolean;

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -702,6 +702,15 @@ function createResponse(options) {
     };
 
     /**
+     *  Function: _getLocals
+     * 
+     *  Returns all the locals that were set.
+     */
+    mockResponse._getLocals = function() {
+        return mockResponse.locals;
+    };
+
+    /**
      * Function: _getData
      *
      *  The data sent to the user.

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -142,6 +142,9 @@ describe('mockResponse', function() {
       expect(response).to.have.property('_getHeaders');
       expect(response._getHeaders).to.be.a('function');
 
+      expect(response).to.have.property('_getLocals');
+      expect(response._getLocals).to.be.a('function');
+
       expect(response).to.have.property('_getData');
       expect(response._getData).to.be.a('function');
 
@@ -1146,6 +1149,22 @@ describe('mockResponse', function() {
         };
         response.type('txt');
         expect(response._getHeaders()).to.deep.equal(headers);
+      });
+
+    });
+
+    describe('._getLocals()', function() {
+
+      it('should return empty object when no locals have been set', function() {
+        expect(response._getLocals()).to.deep.equal({});
+      });
+
+      it('should set the locals -object correctly', function() {
+        var locals = {
+          token: 'Test'
+        };
+        response.locals = locals;
+        expect(response._getLocals()).to.deep.equal(locals);
       });
 
     });


### PR DESCRIPTION
ResponseOptions seems to be missing typings for "locals", so I added it.

A helper method to get locals has been added to MockResponse. Additional tests have been implemented to make sure that the helper method works. 

Tests pass and the code has been linted.