### PR TITLE
Fix for mock response case-insensitvity

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -35,18 +35,11 @@ var typeis = require('type-is');
 var accepts = require('accepts');
 var EventEmitter = require('events').EventEmitter;
 var Readable = require('stream').Readable;
+var utils = require('./utils');
 
 var standardRequestOptions = [
     'method', 'url', 'originalUrl', 'baseUrl', 'path', 'params', 'session', 'cookies', 'headers', 'body', 'query', 'files'
 ];
-
-function convertKeysToLowerCase(map) {
-    var newMap = {};
-    for(var key in map) {
-        newMap[key.toLowerCase()] = map[key];
-    }
-    return newMap;
-}
 
 function createRequest(options) {
 
@@ -76,7 +69,7 @@ function createRequest(options) {
     if (options.signedCookies) {
         mockRequest.signedCookies = options.signedCookies;
     }
-    mockRequest.headers = options.headers ? convertKeysToLowerCase(options.headers) : {};
+    mockRequest.headers = options.headers ? utils.convertKeysToLowerCase(options.headers) : {};
     mockRequest.body = options.body ? options.body : {};
     mockRequest.query = options.query ? options.query : {};
     mockRequest.files = options.files ? options.files : {};

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -29,6 +29,7 @@ var WritableStream = require('./mockWritableStream');
 var EventEmitter = require('./mockEventEmitter');
 var mime = require('mime');
 var http = require('./node/http');
+var utils = require('./utils');
 
 function createResponse(options) {
 
@@ -138,7 +139,7 @@ function createResponse(options) {
         // should not be overwritten but be merged with the headers
         // passed into `mockResponse.writeHead`.
         if (headers) {
-            Object.assign(mockResponse._headers, headers);
+            Object.assign(mockResponse._headers, utils.convertKeysToLowerCase(headers));
         }
 
     };
@@ -200,7 +201,7 @@ function createResponse(options) {
 
             case 3:
                 _formatData(a);
-                mockResponse._headers = b;
+                mockResponse._headers = utils.convertKeysToLowerCase(b);
                 mockResponse.statusCode = c;
                 console.warn('WARNING: Called send() with deprecated three parameters');
                 break;
@@ -535,9 +536,7 @@ function createResponse(options) {
      *   Returns a particular header by name.
      */
     mockResponse.get = mockResponse.getHeader = function(name) {
-        return mockResponse._headers[name] ||
-            mockResponse._headers[name.toLowerCase()] ||
-            mockResponse._headers[name.toUpperCase()];
+        return mockResponse._headers[name.toLowerCase()];
     };
 
     /**
@@ -547,7 +546,7 @@ function createResponse(options) {
      *   Set a particular header by name.
      */
     mockResponse.setHeader = function(name, value) {
-        mockResponse._headers[name] = value;
+        mockResponse._headers[name.toLowerCase()] = value;
         return value;
     };
 
@@ -557,7 +556,7 @@ function createResponse(options) {
      *   Removes an HTTP header by name.
      */
     mockResponse.removeHeader = function(name) {
-        delete mockResponse._headers[name];
+        delete mockResponse._headers[name.toLowerCase()];
     };
 
     /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports.convertKeysToLowerCase = function(map) {
+    var newMap = {};
+    for(var key in map) {
+        newMap[key.toLowerCase()] = map[key];
+    }
+    return newMap;
+};

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -825,7 +825,7 @@ describe('mockResponse', function() {
       it('merges the given headers with the ones specified earlier (set with `setHeader`)', function() {
         response.setHeader('Access-Control-Allow-Origin', '*');
         response.writeHead(200, {'Access-Control-Max-Age': '86400'});
-        expect(response._getHeaders()).to.contain.all.keys({'Access-Control-Allow-Origin': '*', 'Access-Control-Max-Age': '86400'});
+        expect(response._getHeaders()).to.contain.all.keys({'access-control-allow-origin': '*', 'access-control-max-age': '86400'});
       });
 
     });
@@ -883,6 +883,9 @@ describe('mockResponse', function() {
 
         response.header('name2', 'value2');
         expect(response.getHeader('NAME2')).to.equal('value2');
+
+        response.header('Name3', 'value3');
+        expect(response.getHeader('name3')).to.equal('value3');
       });
 
       it('should throw and error, when called without arguments', function() {
@@ -906,6 +909,20 @@ describe('mockResponse', function() {
         response.set('namer1');
         response.removeHeader('name1');
         expect(response.getHeader('name1')).not.to.exist;
+      });
+
+      it('should delete header regardless of case, when called existing header', function() {
+        response.set('NAME1', 'value1');
+        response.removeHeader('name1');
+        expect(response.getHeader('name1')).not.to.exist;
+
+        response.set('name2', 'value2');
+        response.removeHeader('name2');
+        expect(response.getHeader('NAME2')).not.to.exist;
+
+        response.set('Name3', 'value3');
+        response.removeHeader('name3');
+        expect(response.getHeader('name3')).not.to.exist;
       });
 
       it('should exit silently, when with called non-existing header', function() {
@@ -1145,7 +1162,7 @@ describe('mockResponse', function() {
 
       it('should return true when .end() has been called', function() {
         var headers = {
-          'Content-Type': 'text/plain'
+          'content-type': 'text/plain'
         };
         response.type('txt');
         expect(response._getHeaders()).to.deep.equal(headers);


### PR DESCRIPTION
Failing test case included.

Need to lower case all header names when saving.

Also lower case when querying the headers (`.getHeader`, `._getHeaders`, `.removeHeader`)