### PR TITLE
Throw an error object instead of a string

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -109,7 +109,7 @@ function createResponse(options) {
     mockResponse.writeHead = function(statusCode, statusMessage, headers) {
 
         if (_endCalled) {
-            throw 'The end() method has already been called.';
+            throw new Error('The end() method has already been called.');
         }
 
         if (mockResponse.headersSent) {


### PR DESCRIPTION
Seems more of a correct approach to throw an error object, in case you attach extra properties to the error later on - as I found you cannot do if the error is a string!