### PR TITLE
Support for range function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+NEXT RELEASE
+-------  
+  
+  - Added `.range()` on a mocked request mimicking the [same function](http://expressjs.com/en/4x/api.html#req.range) on Express' request. [#175][175]
+
+  [175]: https://github.com/howardabrams/node-mocks-http/pull/175
+  
 v 1.7.2
 -------  
   

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ option | description | default value
 `query` | object hash with query values | {}
 `files` | object hash with values | {}
 
+The object returned from this function also supports the [Express request](http://expressjs.com/en/4x/api.html#req) functions ([`.accepts()`](http://expressjs.com/en/4x/api.html#req.accepts), [`.is()`](http://expressjs.com/en/4x/api.html#req.is), [`.get()`](http://expressjs.com/en/4x/api.html#req.get), [`.range()`](http://expressjs.com/en/4x/api.html#req.range), etc.). Please send a PR for any missing functions.
+
 ### .createResponse()
 
 ```js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,12 +38,12 @@ gulp.task('coverage', function (done) {
         .pipe(istanbul.hookRequire())
         .on('finish', function () {
             gulp.src(files.test)
-            .pipe(mocha({reporter: 'dot'}))
-            .pipe(istanbul.writeReports({
-                dir: './coverage',
-                reporters: ['lcov', 'json', 'html'],
-                reportOpts: { dir: './coverage' }
-            }))
-            .on('end', done);
+                .pipe(mocha({reporter: 'dot'}))
+                .pipe(istanbul.writeReports({
+                    dir: './coverage',
+                    reporters: ['lcov', 'json', 'html'],
+                    reportOpts: { dir: './coverage' }
+                }))
+                .on('end', done);
         });
 });

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -33,6 +33,7 @@
 var url = require('url');
 var typeis = require('type-is');
 var accepts = require('accepts');
+var parseRange = require('range-parser');
 var EventEmitter = require('events').EventEmitter;
 var utils = require('./utils');
 
@@ -188,6 +189,40 @@ function createRequest(options) {
     mockRequest.accepts = function(types) {
         var Accepts = accepts(mockRequest);
         return Accepts.type(types);
+    };
+
+    /**
+     * Function: range
+     *
+     * Parse Range header field, capping to the given `size`.
+     *
+     * Unspecified ranges such as "0-" require knowledge of your resource length. In
+     * the case of a byte range this is of course the total number of bytes. If the
+     * Range header field is not given `undefined` is returned, `-1` when unsatisfiable,
+     * and `-2` when syntactically invalid.
+     *
+     * When ranges are returned, the array has a "type" property which is the type of
+     * range that is required (most commonly, "bytes"). Each array element is an object
+     * with a "start" and "end" property for the portion of the range.
+     *
+     * The "combine" option can be set to `true` and overlapping & adjacent ranges
+     * will be combined into a single range.
+     *
+     * NOTE: remember that ranges are inclusive, so for example "Range: users=0-3"
+     * should respond with 4 users when available, not 3.
+     *
+     * @param {number} size
+     * @param {object} [opts]
+     * @param {boolean} [opts.combine=false]
+     * @return {false|number|array}
+     * @public
+     */
+    mockRequest.range = function(size, opts) {
+        var range = mockRequest.get('Range');
+        if (!range) {
+            return;
+        }
+        return parseRange(size, range, opts);
     };
 
     /**

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -488,7 +488,7 @@ function createResponse(options) {
             // concat the new and prev vals
             value = Array.isArray(prev) ? prev.concat(val)
                 : Array.isArray(val) ? [prev].concat(val)
-                : [prev, val];
+                    : [prev, val];
         }
 
         return mockResponse.set(field, value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mocks-http",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Added in `.range()` function to mock request, including tests.

Also tidied up lint warnings and updated version in package-lock.json.