### PR TITLE
Remove unused `net` npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3604,11 +3604,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
-    "net": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
-      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "merge-descriptors": "^1.0.1",
     "methods": "^1.1.2",
     "mime": "^1.3.4",
-    "net": "^1.0.2",
     "parseurl": "^1.3.1",
     "range-parser": "^1.2.0",
     "type-is": "^1.6.16"


### PR DESCRIPTION
This pull request removes the [`net`](https://www.npmjs.com/package/net) npm package from the dependencies.

If you take a closer look, you'll see that all the `net` npm package does is [globalise the `net` module](https://github.com/sleeplessinc/net/blob/26b11bb4617efc91e95fef4d8fef350980753563/index.js).

I took a look at the [usage of `net` in `node-mocks-http`](https://github.com/howardabrams/node-mocks-http/blob/15e8b2bb27128b373e4643fbbf2dcd64db6e6437/lib/express/mock-request.js#L7) and I can see that it is using the native node [`net` module](https://nodejs.org/docs/latest-v8.x/api/net.html#net_net_isip_input) directly, which means there's no need to install the additional package.


