### PR TITLE
feat: add convenience method _getJSONData

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ exports['routeHandler - Simple testing'] = function(test) {
 
     routeHandler(request, response);
 
-    var data = JSON.parse( response._getData() );
+    var data = response._getJSONData(); // short-hand for JSON.parse( response._getData() );
     test.equal("Bob Dog", data.name);
     test.equal(42, data.age);
     test.equal("bob@dog.com", data.email);

--- a/examples/express-route.js
+++ b/examples/express-route.js
@@ -45,7 +45,7 @@ exports['routeHandler - Simple testing'] = function(test) {
 
     routeHandler(request, response);
 
-    var data = JSON.parse(response._getData());
+    var data = response._getJSONData();
 
     test.equal('Bob Dog', data.name);
     test.equal(42, data.age);

--- a/examples/express-status-vs-json.js
+++ b/examples/express-status-vs-json.js
@@ -37,7 +37,7 @@ exports['routeHandler - Simple testing of status() vs json()'] = function(test) 
 
     routeHandler(request, response);
 
-    var data = JSON.parse(response._getData());
+    var data = response._getJSONData();
 
     test.equal('Bob Dog', data.name);
     test.equal(42, data.age);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -85,6 +85,7 @@ declare module 'node-mocks-http' {
         _isEndCalled: () => boolean;
         _getHeaders: () => Headers;
         _getData: () => any;
+        _getJSONData: () => any;
         _getBuffer: () => Buffer;
         _getLocals: () => any;
         _getStatusCode: () => number;

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -702,7 +702,7 @@ function createResponse(options) {
 
     /**
      *  Function: _getLocals
-     * 
+     *
      *  Returns all the locals that were set.
      */
     mockResponse._getLocals = function() {
@@ -716,6 +716,15 @@ function createResponse(options) {
      */
     mockResponse._getData = function() {
         return _data;
+    };
+
+    /**
+     * Function: _getJSONData
+     *
+     *  The data sent to the user as JSON.
+     */
+    mockResponse._getJSONData = function() {
+        return JSON.parse(_data);
     };
 
     /**

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -1221,6 +1221,18 @@ describe('mockResponse', function() {
 
     });
 
+    describe('._getJSONData()', function() {
+
+      it('will be deprecated in 2.0');
+
+      it('should return sent data', function() {
+        var data = { a: 1, b: { c: 2 }};
+        response.send(JSON.stringify(data));
+        expect(response._getJSONData()).to.deep.equal(data);
+      });
+
+    });
+
     describe('._getStatusCode()', function() {
 
       it('will be deprecated in 2.0');


### PR DESCRIPTION
Thanks for the lib! How would you feel about a small method to parse returned data as JSON? Would cut down on some common duplicate code we have. If you like the idea, I'll add some examples to the README / tests as well.