### PR TITLE
fix: enable method chaining

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -215,6 +215,7 @@ function createResponse(options) {
         mockResponse.emit('send');
         mockResponse.end();
 
+        return mockResponse;
     };
 
     /**
@@ -273,6 +274,7 @@ function createResponse(options) {
         mockResponse.emit('send');
         mockResponse.end();
 
+        return mockResponse;
     };
 
     /**
@@ -306,6 +308,7 @@ function createResponse(options) {
         mockResponse.emit('send');
         mockResponse.end();
 
+        return mockResponse;
     };
 
     /**

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -617,6 +617,11 @@ describe('mockResponse', function() {
 
       it('should mimic Express Response.send()');
 
+      it('should return the response', function () {
+        var response = mockResponse.createResponse();
+        expect(response.send({})).to.equal(response);
+      });
+
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.json()
@@ -669,6 +674,10 @@ describe('mockResponse', function() {
       it('should set data to "null" if passed null', function () {
         response.json(null);
         expect(response._getData()).to.equal('null');
+      });
+
+      it('should return the response', function () {
+        expect(response.json(null)).to.equal(response);
       });
 
       // reference : https://github.com/howardabrams/node-mocks-http/pull/98
@@ -734,6 +743,10 @@ describe('mockResponse', function() {
       it('should set data to "null" if passed null', function () {
         response.jsonp(null);
         expect(response._getData()).to.equal('null');
+      });
+
+      it('should return the response', function () {
+        expect(response.jsonp(null)).to.equal(response);
       });
     });
 


### PR DESCRIPTION
calling `.send()`, `.json()` and `.jsonp()` does not yield the response object but it should.

i.e. having a request handler which calls `res.json({}).end()` will fail.

This PR addresses this issue.