### PR TITLE
Copy all types from IncomingHeaders

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -18,7 +18,61 @@ declare module 'node-mocks-http' {
     }
 
     export interface Headers {
-        [key: string]: string;
+        'accept'?: string;
+        'accept-language'?: string;
+        'accept-patch'?: string;
+        'accept-ranges'?: string;
+        'access-control-allow-credentials'?: string;
+        'access-control-allow-headers'?: string;
+        'access-control-allow-methods'?: string;
+        'access-control-allow-origin'?: string;
+        'access-control-expose-headers'?: string;
+        'access-control-max-age'?: string;
+        'age'?: string;
+        'allow'?: string;
+        'alt-svc'?: string;
+        'authorization'?: string;
+        'cache-control'?: string;
+        'connection'?: string;
+        'content-disposition'?: string;
+        'content-encoding'?: string;
+        'content-language'?: string;
+        'content-length'?: string;
+        'content-location'?: string;
+        'content-range'?: string;
+        'content-type'?: string;
+        'cookie'?: string;
+        'date'?: string;
+        'expect'?: string;
+        'expires'?: string;
+        'forwarded'?: string;
+        'from'?: string;
+        'host'?: string;
+        'if-match'?: string;
+        'if-modified-since'?: string;
+        'if-none-match'?: string;
+        'if-unmodified-since'?: string;
+        'last-modified'?: string;
+        'location'?: string;
+        'pragma'?: string;
+        'proxy-authenticate'?: string;
+        'proxy-authorization'?: string;
+        'public-key-pins'?: string;
+        'range'?: string;
+        'referer'?: string;
+        'retry-after'?: string;
+        'set-cookie'?: string[];
+        'strict-transport-security'?: string;
+        'tk'?: string;
+        'trailer'?: string;
+        'transfer-encoding'?: string;
+        'upgrade'?: string;
+        'user-agent'?: string;
+        'vary'?: string;
+        'via'?: string;
+        'warning'?: string;
+        'www-authenticate'?: string;
+        [header: string]: string | string[] | undefined;
     }
 
     export interface Query {


### PR DESCRIPTION
This is a completely copy of the full IncomingHeaders type defined here https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e9e404ac8e23dcafd02f57db02915d848c4454b3/types/node/http.d.ts#L9-L64

I'll submit a second PR in a second which adds a shorter but compatible type so you could merge that one if you prefer. I would recommend this PR thought as it seems to be the most accurate.