### PR TITLE
Allow array of strings (or undefined) in headers

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -18,7 +18,7 @@ declare module 'node-mocks-http' {
     }
 
     export interface Headers {
-        [key: string]: string;
+        [key: string]: string | string[] | undefined;
     }
 
     export interface Query {


### PR DESCRIPTION
This matches the types here https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e9e404ac8e23dcafd02f57db02915d848c4454b3/types/node/http.d.ts#L63

This is the simplest change that allows a header to be `undefined` or an array of strings. I recommend merging #192 instead of this one though...