### PR TITLE
Add socket option to mockRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ option | description | default value
 `params` | object hash with params | {}
 `session` | object hash with session values | `undefined`
 `cookies` | object hash with request cookies | {}
+`socket` | object hash with request socket | {}
 `signedCookies` | object hash with signed cookies | `undefined`
 `headers` | object hash with request headers | {}
 `body` | object hash with body | {}

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -73,6 +73,7 @@ function createRequest(options) {
     mockRequest.body = options.body ? options.body : {};
     mockRequest.query = options.query ? options.query : {};
     mockRequest.files = options.files ? options.files : {};
+    mockRequest.socket = options.socket ? options.socket : {};
 
     //parse query string from url to object
     if (Object.keys(mockRequest.query).length === 0) {


### PR DESCRIPTION
# Overview
I use node-mocks-http with koa2.
when I call ctx.cookies.get() methd in koa2 customer middleware，it throw an error："TypeError: Cannot read property 'encrypted' of undefined".

# Suggestions
I found that Koa2 check it's _this.socket.encrypted_ when user call ctx.cookies.get() methd,
It seems that the node-mocks-http mockRequest instance need a **socket** property.

