### PR TITLE
Implement response.getHeaders()

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -528,6 +528,15 @@ function createResponse(options) {
     };
 
     /**
+     * Function: getHeaders
+     *
+     *   Returns a shallow copy of the current outgoing headers.
+     */
+    mockResponse.getHeaders = function() {
+        return JSON.parse(JSON.stringify(mockResponse._headers));
+    };
+
+    /**
      * Function: getHeader
      * Function: get
      *

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -987,6 +987,42 @@ describe('mockResponse', function() {
 
     });
 
+    describe('.getHeaders()', function() {
+      var response;
+
+      beforeEach(function() {
+        response = mockResponse.createResponse();
+      });
+
+      afterEach(function() {
+        response = null;
+      });
+
+      it('should return an empty object when no cookies were set', function() {
+        expect(response.getHeaders()).to.deep.equal({});
+      });
+
+      it('should return cookies previously set', function() {
+        response.setHeader('name1', 'value1');
+        response.setHeader('name2', 'value2');
+
+        var headers = response.getHeaders();
+
+        expect(headers['name1']).to.equal('value1');
+        expect(headers['name2']).to.equal('value2');
+      });
+
+      it('should return a shallow copy', function() {
+        var array = [ 1, 2 ];
+
+        response.setHeader('name1', array);
+        var headers = response.getHeaders();
+
+        expect(headers['name1']).not.to.equal(array);
+        expect(headers['name1']).to.deep.equal(array);
+      });
+    });
+
     describe('.removeHeader()', function() {
       var response;
 

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -9,26 +9,26 @@ chai.use(sinonChai);
 var mockResponse = require('../../lib/mockResponse');
 var mockRequest = require('../../lib/mockRequest');
 
-describe('mockResponse', function() {
+describe('mockResponse', function () {
 
-  it('should expose .createResponse()', function() {
+  it('should expose .createResponse()', function () {
     expect(mockResponse.createResponse).to.be.a('function');
   });
 
-  describe('.createResponse()', function() {
+  describe('.createResponse()', function () {
     var response;
 
-    before(function() {
+    before(function () {
       response = mockResponse.createResponse({
-        locals: {a: 'b'}
+        locals: { a: 'b' }
       });
     });
 
-    it('should return an object', function() {
+    it('should return an object', function () {
       expect(response).to.be.an('object');
     });
 
-    it('should expose Express Response methods', function() {
+    it('should expose Express Response methods', function () {
       expect(response).to.have.property('cookie');
       expect(response.cookie).to.be.a('function');
 
@@ -76,7 +76,7 @@ describe('mockResponse', function() {
       expect(response.render).to.be.a('function');
     });
 
-    it('should expose Node OutgoingMessage methods', function() {
+    it('should expose Node OutgoingMessage methods', function () {
       expect(response).to.have.property('getHeader');
       expect(response.getHeader).to.be.a('function');
 
@@ -93,12 +93,12 @@ describe('mockResponse', function() {
       expect(response.end).to.be.a('function');
     });
 
-    it('should expose Node ServerResponse methods', function() {
+    it('should expose Node ServerResponse methods', function () {
       expect(response).to.have.property('writeHead');
       expect(response.writeHead).to.be.a('function');
     });
 
-    it('should expose Node WritableStream methods', function() {
+    it('should expose Node WritableStream methods', function () {
       expect(response).to.have.property('destroy');
       expect(response.destroy).to.be.a('function');
 
@@ -106,7 +106,7 @@ describe('mockResponse', function() {
       expect(response.destroySoon).to.be.a('function');
     });
 
-    it('should expose Node EventEmitter methods', function() {
+    it('should expose Node EventEmitter methods', function () {
       expect(response).to.have.property('addListener');
       expect(response.addListener).to.be.a('function');
 
@@ -135,7 +135,7 @@ describe('mockResponse', function() {
       expect(response.prependListener).to.be.a('function');
     });
 
-    it('should expose helper methods', function() {
+    it('should expose helper methods', function () {
       expect(response).to.have.property('_isEndCalled');
       expect(response._isEndCalled).to.be.a('function');
 
@@ -170,28 +170,28 @@ describe('mockResponse', function() {
       expect(response._getRenderData).to.be.a('function');
     });
 
-    it('shoud initialize with default options', function() {
+    it('shoud initialize with default options', function () {
       expect(response.statusCode).to.equal(200);
       expect(response.cookies).to.deep.equal({});
-      expect(response.locals).to.deep.equal({a: 'b'});
+      expect(response.locals).to.deep.equal({ a: 'b' });
     });
 
   });
 
-  describe('Express Response methods', function() {
+  describe('Express Response methods', function () {
 
-    describe('.cookie()', function() {
+    describe('.cookie()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
-      it('should set cookie, when called with, name and value', function() {
+      it('should set cookie, when called with, name and value', function () {
         var cookie = {
           value: 'value',
           options: undefined
@@ -200,7 +200,7 @@ describe('mockResponse', function() {
         expect(response.cookies.name).to.deep.equal(cookie);
       });
 
-      it('should set cookie, when called with, name, value and options', function() {
+      it('should set cookie, when called with, name, value and options', function () {
         var cookie = {
           value: 'value',
           options: {
@@ -212,11 +212,11 @@ describe('mockResponse', function() {
         expect(response.cookies.name).to.deep.equal(cookie);
       });
 
-      it('should throw and error, when called without arguments', function() {
+      it('should throw and error, when called without arguments', function () {
         expect(response.cookie).to.throw;
       });
 
-      it('should allow chaining', function() {
+      it('should allow chaining', function () {
         var cookie = {
           value: 'value',
           options: {
@@ -231,18 +231,18 @@ describe('mockResponse', function() {
 
     });
 
-    describe('.clearCookie()', function() {
+    describe('.clearCookie()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
-      it('should set an already expired date to the cookie, when called with existing cookie', function() {
+      it('should set an already expired date to the cookie, when called with existing cookie', function () {
         var cookie = {
           value: '',
           options: {
@@ -255,7 +255,7 @@ describe('mockResponse', function() {
         expect(response.cookies.name).to.deep.equal(cookie);
       });
 
-      it('should keep the options of the cookie except expiration date and path, if provided', function() {
+      it('should keep the options of the cookie except expiration date and path, if provided', function () {
         var cookie = {
           value: '',
           options: {
@@ -266,15 +266,15 @@ describe('mockResponse', function() {
           }
         };
         response.cookie('name', 'value');
-        response.clearCookie('name', {expires: new Date(), path: '/path', domain: 'domain', httpOnly: true});
+        response.clearCookie('name', { expires: new Date(), path: '/path', domain: 'domain', httpOnly: true });
         expect(response.cookies.name).to.deep.equal(cookie);
       });
 
-      it('should return silently, when called with non-existing cookie', function() {
+      it('should return silently, when called with non-existing cookie', function () {
         expect(response.clearCookie.bind(null, 'invalid')).not.to.throw;
       });
 
-      it('should allow chaining', function() {
+      it('should allow chaining', function () {
         response.cookie('name', 'value');
         var chainedResponse = response.clearCookie('name');
         expect(chainedResponse).to.deep.equal(response);
@@ -282,43 +282,43 @@ describe('mockResponse', function() {
 
     });
 
-    describe('.status()', function() {
+    describe('.status()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
-      it('should set cookie, when called with, name and value', function() {
+      it('should set cookie, when called with, name and value', function () {
         response.status(404);
         expect(response.statusCode).to.equal(404);
       });
 
-      it('should statusCode to undefined, when called without arguments', function() {
+      it('should statusCode to undefined, when called without arguments', function () {
         response.status();
         expect(response.statusCode).to.not.exist;
       });
 
     });
 
-    describe('.sendStatus()', function() {
+    describe('.sendStatus()', function () {
       var response;
 
-      before(function() {
+      before(function () {
         response = mockResponse.createResponse();
         sinon.spy(response, 'send');
       });
 
-      after(function() {
+      after(function () {
         response.send.restore();
         response = null;
       });
 
-      it('should set .statusCode, set .type to "text/plain", and call .send()', function() {
+      it('should set .statusCode, set .type to "text/plain", and call .send()', function () {
         response.sendStatus(404);
         expect(response.statusCode).to.equal(404);
         expect(response.get('Content-Type')).to.equal('text/plain');
@@ -326,74 +326,74 @@ describe('mockResponse', function() {
       });
     });
 
-    describe('.contentType()/.type()', function() {
+    describe('.contentType()/.type()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      it('should set "Content-Type"', function() {
+      it('should set "Content-Type"', function () {
         response.type('html');
         expect(response.get('Content-Type')).to.equal('text/html');
         response.contentType('txt');
         expect(response.get('Content-Type')).to.equal('text/plain');
       });
 
-      it('should trow an error, when called without arguments', function() {
+      it('should trow an error, when called without arguments', function () {
         expect(response.type).to.throw;
         expect(response.contentType).to.throw;
       });
 
     });
 
-    describe('.vary()', function() {
+    describe('.vary()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
         sinon.spy(response, 'setHeader');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response.setHeader.restore();
         response = null;
       });
 
-      it('should set vary header, when called with a single field', function() {
+      it('should set vary header, when called with a single field', function () {
         response.vary('value1');
         expect(response.setHeader).to.have.been.calledWith('Vary', 'value1');
         expect(response.get('Vary')).to.equal('value1');
       });
 
-      it('should set vary header, when called with a an array of fields', function() {
-        response.vary([ 'value1', 'value2' ]);
+      it('should set vary header, when called with a an array of fields', function () {
+        response.vary(['value1', 'value2']);
         expect(response.setHeader).to.have.been.calledWith('Vary', 'value1, value2');
         expect(response.get('Vary')).to.equal('value1, value2');
       });
 
-      it('should not duplicate vary header values (regardless of case)', function() {
-        response.vary([ 'value1', 'value2' ]);
-        response.vary([ 'Value1', 'VALUE2', 'value3' ]);
+      it('should not duplicate vary header values (regardless of case)', function () {
+        response.vary(['value1', 'value2']);
+        response.vary(['Value1', 'VALUE2', 'value3']);
         expect(response.get('Vary')).to.equal('value1, value2, value3');
       });
 
     });
 
-    describe('.append()', function() {
+    describe('.append()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
         sinon.spy(response, 'setHeader');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response.setHeader.restore();
         response = null;
       });
 
-      it('should append multiple headers', function() {
+      it('should append multiple headers', function () {
         response.append('Link', '<http://localhost/>');
         response.append('Link', '<http://localhost:80/>');
 
@@ -404,13 +404,13 @@ describe('mockResponse', function() {
         expect(response.get('Link')).to.deep.equal(['<http://localhost/>', '<http://localhost:80/>']);
       });
 
-      it('should accept array of values', function() {
+      it('should accept array of values', function () {
         response.append('Set-Cookie', ['foo=bar', 'fizz=buzz']);
         expect(response.setHeader).to.have.been.calledWith('Set-Cookie', ['foo=bar', 'fizz=buzz']);
         expect(response.get('Set-Cookie')).to.deep.equal(['foo=bar', 'fizz=buzz']);
       });
 
-      it('should get reset by res.set(field, val)', function() {
+      it('should get reset by res.set(field, val)', function () {
         response.append('Link', '<http://localhost/>');
         response.append('Link', '<http://localhost:80/>');
         response.set('Link', '<http://127.0.0.1/>');
@@ -418,7 +418,7 @@ describe('mockResponse', function() {
         expect(response.get('Link')).to.equal('<http://127.0.0.1/>');
       });
 
-      it('should work with res.set(field, val) first', function() {
+      it('should work with res.set(field, val) first', function () {
         response.set('Link', '<http://localhost/>');
         response.append('Link', '<http://localhost:80/>');
         expect(response.setHeader).to.have.been.calledTwice;
@@ -426,37 +426,37 @@ describe('mockResponse', function() {
       });
     });
 
-    describe('.location()', function() {
+    describe('.location()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      it('sets the Location header to the given path', function() {
+      it('sets the Location header to the given path', function () {
         response.location('/a/nice/location');
         expect(response.get('Location')).to.equal('/a/nice/location');
       });
 
-      it('returns the response object', function() {
+      it('returns the response object', function () {
         expect(response.location('')).to.equal(response);
       });
     });
 
-    describe('.set()/.header()', function() {
+    describe('.set()/.header()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
         sinon.spy(response, 'setHeader');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response.setHeader.restore();
         response = null;
       });
 
-      it('should set header, when called with name and value strings', function() {
+      it('should set header, when called with name and value strings', function () {
         response.set('name1', 'value1');
         expect(response.setHeader).to.have.been.calledWith('name1', 'value1');
         expect(response.get('name1')).to.equal('value1');
@@ -466,7 +466,7 @@ describe('mockResponse', function() {
         expect(response.get('name2')).to.equal('value2');
       });
 
-      it('should convert value to string, when called with called with non-string value', function() {
+      it('should convert value to string, when called with called with non-string value', function () {
         var num = 1;
         var obj = { key: 'value' };
         var bool = false;
@@ -484,12 +484,12 @@ describe('mockResponse', function() {
         expect(response.get('bool')).to.equal(bool.toString());
       });
 
-      it('returns the header value when called with only a key', function() {
+      it('returns the header value when called with only a key', function () {
         response.header('x', 'y');
         expect(response.header('x')).to.equal('y');
       });
 
-      it('should set headers, when called with a hash of key/values', function() {
+      it('should set headers, when called with a hash of key/values', function () {
         var headers = {
           name1: 'value1',
           name2: 'value2'
@@ -504,25 +504,25 @@ describe('mockResponse', function() {
         expect(response.get('name2')).to.equal('value2');
       });
 
-      it('should throw an error when called without arguments', function() {
+      it('should throw an error when called without arguments', function () {
         expect(response.set).to.throw;
         expect(response.header).to.throw;
       });
 
     });
 
-    describe('.get()', function() {
+    describe('.get()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
-      it('should get header, when called existing header name', function() {
+      it('should get header, when called existing header name', function () {
         response.set('name1', 'value1');
         expect(response.get('name1')).to.equal('value1');
 
@@ -530,27 +530,27 @@ describe('mockResponse', function() {
         expect(response.get('name2')).to.equal('value2');
       });
 
-      it('should throw and error, when called without arguments', function() {
+      it('should throw and error, when called without arguments', function () {
         expect(response.get).to.throw;
         expect(response.getHeader).to.throw;
       });
 
     });
 
-    describe('.redirect()', function() {
+    describe('.redirect()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
       it('should mimic Express Response.redirect()');
 
-      it('should redirect with status 302, when not specified', function() {
+      it('should redirect with status 302, when not specified', function () {
         var url = '/path/to/redirect';
 
         response.redirect(url);
@@ -558,7 +558,7 @@ describe('mockResponse', function() {
         expect(response._getRedirectUrl()).to.equal(url);
       });
 
-      it('should redirect with status specified status', function() {
+      it('should redirect with status specified status', function () {
         var statusCode = 301;
         var url = '/path/to/redirect';
 
@@ -570,22 +570,22 @@ describe('mockResponse', function() {
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.render()
-    describe('.render()', function() {
+    describe('.render()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
         sinon.spy(response, 'emit');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response.emit.restore();
         response = null;
       });
 
       it('should mimic Express Response.render()');
 
-      it('should accept view argument only', function() {
+      it('should accept view argument only', function () {
         var view = 'view';
 
         response.render(view);
@@ -597,7 +597,7 @@ describe('mockResponse', function() {
         expect(response.emit).to.have.been.calledWith('finish');
       });
 
-      it('should accept view and data arguments', function() {
+      it('should accept view and data arguments', function () {
         var view = 'view';
         var data = { key: 'value' };
 
@@ -610,7 +610,7 @@ describe('mockResponse', function() {
         expect(response.emit).to.have.been.calledWith('finish');
       });
 
-      it('should accept view, data, and callback arguments', function() {
+      it('should accept view, data, and callback arguments', function () {
         var view = 'view';
         var data = { key: 'value' };
         var callback = sinon.stub();
@@ -623,7 +623,7 @@ describe('mockResponse', function() {
         expect(response.emit).not.to.have.been.called;
       });
 
-      it('should accept view and callback arguments', function() {
+      it('should accept view and callback arguments', function () {
         var view = 'view';
         var callback = sinon.stub();
 
@@ -637,7 +637,7 @@ describe('mockResponse', function() {
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.send()
-    describe('.send()', function() {
+    describe('.send()', function () {
 
       it('should mimic Express Response.send()');
 
@@ -649,22 +649,22 @@ describe('mockResponse', function() {
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.json()
-    describe('.json()', function() {
+    describe('.json()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
         sinon.spy(response, 'emit');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response.emit.restore();
         response = null;
       });
 
       it('method should mimic Express Response.json()');
 
-      it('should emit send and end events', function() {
+      it('should emit send and end events', function () {
         response.json({});
         expect(response.emit).to.have.been.calledThrice;
         expect(response.emit).to.have.been.calledWith('send');
@@ -673,7 +673,7 @@ describe('mockResponse', function() {
       });
 
       it('should set data and statusCode if first argument is data and second is number', function () {
-        response.json({},400);
+        response.json({}, 400);
         expect(response.statusCode).to.equal(400);
         expect(response._getData()).to.equal('{}');
       });
@@ -705,35 +705,35 @@ describe('mockResponse', function() {
       });
 
       // reference : https://github.com/howardabrams/node-mocks-http/pull/98
-      it('should call .write()', function() {
+      it('should call .write()', function () {
         var originalWrite = response.write.bind(response);
-        var hackedContent = JSON.stringify({foo: 'bar'});
-        response.write = function(data, encoding) {
+        var hackedContent = JSON.stringify({ foo: 'bar' });
+        response.write = function (data, encoding) {
           return originalWrite(hackedContent, encoding);
         };
-        response.json({hello: 'world'});
+        response.json({ hello: 'world' });
         expect(response._getData()).to.eql(hackedContent);
       });
 
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.jsonp()
-    describe('.jsonp()', function() {
+    describe('.jsonp()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
         sinon.spy(response, 'emit');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response.emit.restore();
         response = null;
       });
 
       it('method should mimic Express Response.jsonp()');
 
-      it('should emit send and end events', function() {
+      it('should emit send and end events', function () {
         response.jsonp({});
         expect(response.emit).to.have.been.calledThrice;
         expect(response.emit).to.have.been.calledWith('send');
@@ -742,7 +742,7 @@ describe('mockResponse', function() {
       });
 
       it('should set data and statusCode if first argument is data and second is number', function () {
-        response.jsonp({},400);
+        response.jsonp({}, 400);
         expect(response.statusCode).to.equal(400);
         expect(response._getData()).to.equal('{}');
       });
@@ -775,11 +775,11 @@ describe('mockResponse', function() {
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.redirect()
-    describe('.redirect()', function() {
+    describe('.redirect()', function () {
       it('method should mimic Express Response.redirect()');
     });
 
-    describe('.format()', function() {
+    describe('.format()', function () {
       var response, request;
 
       beforeEach(function () {
@@ -787,21 +787,21 @@ describe('mockResponse', function() {
         response = mockResponse.createResponse({ req: request });
       });
 
-      it('sends 406 when given no supported formats', function() {
+      it('sends 406 when given no supported formats', function () {
         response.format({});
         expect(response.statusCode).to.equal(406);
         expect(response._getData()).to.equal('Not Acceptable');
       });
 
-      it('throws when no request object is available', function() {
+      it('throws when no request object is available', function () {
         response = mockResponse.createResponse();
 
-        expect(function() {
-          response.format({ html: function() {} });
+        expect(function () {
+          response.format({ html: function () { } });
         }).to.throw(Error, /Request object unavailable/);
       });
 
-      it('calls the handler for the closest accepted type', function() {
+      it('calls the handler for the closest accepted type', function () {
         var htmlSpy = sinon.spy();
         var jsonSpy = sinon.spy();
 
@@ -812,7 +812,7 @@ describe('mockResponse', function() {
         expect(jsonSpy).to.have.been.called;
       });
 
-      it('sends 406 when no match is found', function() {
+      it('sends 406 when no match is found', function () {
         var htmlSpy = sinon.spy();
         var jsonSpy = sinon.spy();
 
@@ -824,7 +824,7 @@ describe('mockResponse', function() {
         expect(response.statusCode).to.equal(406);
       });
 
-      it('runs default function if it exists and no match is found', function() {
+      it('runs default function if it exists and no match is found', function () {
         var defaultSpy = sinon.spy();
         response.format({ default: defaultSpy });
         expect(defaultSpy).to.have.been.called;
@@ -833,12 +833,12 @@ describe('mockResponse', function() {
   });
 
   // TODO: fix in 2.0; methods should be inherited from Node ServerResponse
-  describe('Node ServerResponse methods', function() {
+  describe('Node ServerResponse methods', function () {
 
-    describe('.writeHead()', function() {
+    describe('.writeHead()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
 
         expect(response.statusCode).to.equal(200);
@@ -846,29 +846,29 @@ describe('mockResponse', function() {
         expect(response.getHeaders()).to.be.empty;
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
       it('should inherit from ServerResponse.writeHead()');
 
-      it('writes the statusCode of the response', function() {
+      it('writes the statusCode of the response', function () {
         response.writeHead(400);
         expect(response.statusCode).to.equal(400);
       });
 
-      it('writes the statusMessage of the response', function() {
+      it('writes the statusMessage of the response', function () {
         response.writeHead(400, 'NotOK');
         expect(response.statusMessage).to.equal('NotOK');
       });
 
-      it('writes the headers of the response', function() {
+      it('writes the headers of the response', function () {
         var headers = { 'x-header': 'test llama' };
         response.writeHead(400, headers);
         expect(response.getHeaders()).to.deep.equal(headers);
       });
 
-      it('updates the headersSent property of the response', function() {
+      it('updates the headersSent property of the response', function () {
         var headers = { 'x-header': 'test llama' };
         response.writeHead(400, headers);
         // headers are only sent by node with first body byte
@@ -878,47 +878,47 @@ describe('mockResponse', function() {
         // further updates to headers shouldn't really be reflected in mock headers
         // since these would be transmitted as part of the body (probably breaking chunked encoding)
         // in real life.
-        response.writeHead(500, {'x-header': 'llama party'});
+        response.writeHead(500, { 'x-header': 'llama party' });
         // Should still see same as before
         expect(response.getHeaders()).to.deep.equal(headers);
       });
 
-      it('works with statusMessage and headers as optional', function() {
+      it('works with statusMessage and headers as optional', function () {
         response.writeHead(400);
         expect(response.statusCode).to.equal(400);
         expect(response.statusMessage).to.equal('OK');
         expect(response.getHeaders()).to.be.empty;
       });
 
-      it('works with statusMessage as optional', function() {
+      it('works with statusMessage as optional', function () {
         var headers = { 'x-header': 'test llama' };
         response.writeHead(400, headers);
         expect(response.statusMessage).to.equal('OK');
         expect(response.getHeaders()).to.deep.equal(headers);
       });
 
-      it('works with headers as optional', function() {
+      it('works with headers as optional', function () {
         response.writeHead(400, 'NotOK');
         expect(response.statusMessage).to.equal('NotOK');
         expect(response.getHeaders()).to.be.empty;
       });
 
-      it('works with statusCode, statusMessage, and headers defined', function() {
+      it('works with statusCode, statusMessage, and headers defined', function () {
         var headers = { 'x-header': 'test llama' };
         response.writeHead(400, 'NotOK', headers);
         expect(response.statusMessage).to.equal('NotOK');
         expect(response.getHeaders()).to.deep.equal(headers);
       });
 
-      it('throws if end has already been called', function() {
+      it('throws if end has already been called', function () {
         response.end();
         expect(response.writeHead.bind(response, 200)).to.throw('The end() method has already been called');
       });
 
-      it('merges the given headers with the ones specified earlier (set with `setHeader`)', function() {
+      it('merges the given headers with the ones specified earlier (set with `setHeader`)', function () {
         response.setHeader('Access-Control-Allow-Origin', '*');
-        response.writeHead(200, {'Access-Control-Max-Age': '86400'});
-        expect(response.getHeaders()).to.contain.all.keys({'access-control-allow-origin': '*', 'access-control-max-age': '86400'});
+        response.writeHead(200, { 'Access-Control-Max-Age': '86400' });
+        expect(response.getHeaders()).to.contain.all.keys({ 'access-control-allow-origin': '*', 'access-control-max-age': '86400' });
       });
 
     });
@@ -926,43 +926,43 @@ describe('mockResponse', function() {
   });
 
   // TODO: fix in 2.0; methods should be inherited from Node OutogingMessage
-  describe('Node OutogingMessage methods', function() {
+  describe('Node OutogingMessage methods', function () {
 
-    describe('.setHeader()', function() {
+    describe('.setHeader()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
 
-      it('should set header, when called with name and value strings', function() {
+      it('should set header, when called with name and value strings', function () {
         response.setHeader('name', 'value');
         expect(response.getHeader('name')).to.equal('value');
       });
 
-      it('should throw an error when called without arguments', function() {
+      it('should throw an error when called without arguments', function () {
         expect(response.setHeader).to.throw;
       });
 
     });
 
-    describe('.getHeader()', function() {
+    describe('.getHeader()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
-      it('should get header, when called existing header', function() {
+      it('should get header, when called existing header', function () {
         response.set('name1', 'value1');
         expect(response.getHeader('name1')).to.equal('value1');
 
@@ -970,7 +970,7 @@ describe('mockResponse', function() {
         expect(response.getHeader('name2')).to.equal('value2');
       });
 
-      it('should get header regardless of case, when called existing header', function() {
+      it('should get header regardless of case, when called existing header', function () {
         response.set('NAME1', 'value1');
         expect(response.getHeader('name1')).to.equal('value1');
 
@@ -981,66 +981,66 @@ describe('mockResponse', function() {
         expect(response.getHeader('name3')).to.equal('value3');
       });
 
-      it('should throw and error, when called without arguments', function() {
+      it('should throw and error, when called without arguments', function () {
         expect(response.getHeader).to.throw;
       });
 
     });
 
-    describe('.getHeaders()', function() {
+    describe('.getHeaders()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
-      it('should return an empty object when no cookies were set', function() {
+      it('should return an empty object when no cookies were set', function () {
         expect(response.getHeaders()).to.deep.equal({});
       });
 
-      it('should return cookies previously set', function() {
+      it('should return cookies previously set', function () {
         response.setHeader('name1', 'value1');
         response.setHeader('name2', 'value2');
 
         var headers = response.getHeaders();
 
-        expect(headers['name1']).to.equal('value1');
-        expect(headers['name2']).to.equal('value2');
+        expect(headers.name1).to.equal('value1');
+        expect(headers.name2).to.equal('value2');
       });
 
-      it('should return a shallow copy', function() {
-        var array = [ 1, 2 ];
+      it('should return a shallow copy', function () {
+        var array = [1, 2];
 
         response.setHeader('name1', array);
         var headers = response.getHeaders();
 
-        expect(headers['name1']).not.to.equal(array);
-        expect(headers['name1']).to.deep.equal(array);
+        expect(headers.name1).not.to.equal(array);
+        expect(headers.name1).to.deep.equal(array);
       });
     });
 
-    describe('.removeHeader()', function() {
+    describe('.removeHeader()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      afterEach(function() {
+      afterEach(function () {
         response = null;
       });
 
-      it('should delete header, when with called existing header', function() {
+      it('should delete header, when with called existing header', function () {
         response.set('namer1');
         response.removeHeader('name1');
         expect(response.getHeader('name1')).not.to.exist;
       });
 
-      it('should delete header regardless of case, when called existing header', function() {
+      it('should delete header regardless of case, when called existing header', function () {
         response.set('NAME1', 'value1');
         response.removeHeader('name1');
         expect(response.getHeader('name1')).not.to.exist;
@@ -1054,25 +1054,25 @@ describe('mockResponse', function() {
         expect(response.getHeader('name3')).not.to.exist;
       });
 
-      it('should exit silently, when with called non-existing header', function() {
+      it('should exit silently, when with called non-existing header', function () {
         expect(response.getHeader('name2')).not.to.exist;
         response.removeHeader('name2');
       });
 
-      it('should throw and error, when called without arguments', function() {
+      it('should throw and error, when called without arguments', function () {
         expect(response.removeHeader).to.throw;
       });
 
     });
 
-    describe('.write()', function() {
+    describe('.write()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
-      it('should accept a string and hold it in _data', function() {
+      it('should accept a string and hold it in _data', function () {
         var payload1 = 'payload1';
         var encoding = 'utf8';
         response.write(payload1, encoding);
@@ -1080,7 +1080,7 @@ describe('mockResponse', function() {
         expect(response.getEncoding()).to.equal(encoding);
       });
 
-      it('should accept multiple strings and concatenate them in _data', function() {
+      it('should accept multiple strings and concatenate them in _data', function () {
         var payload1 = 'payload1';
         var payload2 = 'payload2';
         response.write(payload1);
@@ -1088,7 +1088,7 @@ describe('mockResponse', function() {
         expect(response._getData()).to.equal(payload1 + payload2);
       });
 
-      it('should accept a buffer and hold it in _chunks', function() {
+      it('should accept a buffer and hold it in _chunks', function () {
         var payload1 = 'payload1';
         response.write(new Buffer(payload1));
         var chunks = response._getChunks();
@@ -1096,7 +1096,7 @@ describe('mockResponse', function() {
         expect(chunks[0].toString()).to.equal(payload1);
       });
 
-      it('should accept multiple buffers and hold them in _chunks', function() {
+      it('should accept multiple buffers and hold them in _chunks', function () {
         var payload1 = 'payload1';
         var payload2 = 'payload2';
         response.write(new Buffer(payload1));
@@ -1111,15 +1111,15 @@ describe('mockResponse', function() {
 
     });
 
-    describe('.end()', function() {
+    describe('.end()', function () {
       var response;
 
-      beforeEach(function() {
+      beforeEach(function () {
         response = mockResponse.createResponse();
       });
 
       // Issue 119
-      it('only emits end once', function() {
+      it('only emits end once', function () {
         var emits = 0;
         response.emit = function (event) {
           if (event === 'end') {
@@ -1131,13 +1131,13 @@ describe('mockResponse', function() {
         expect(emits).to.eql(1);
       });
 
-      it('should set writableEnded to true', function() {
+      it('should set writableEnded to true', function () {
         response.end();
         expect(response.writableEnded).to.eql(true);
         expect(response.writableFinished).to.eql(true);
       });
 
-      it('writes to _data if a string is supplied', function() {
+      it('writes to _data if a string is supplied', function () {
         var payload1 = 'payload1';
         var encoding = 'utf8';
         response.end(payload1, encoding);
@@ -1145,7 +1145,7 @@ describe('mockResponse', function() {
         expect(response.getEncoding()).to.equal(encoding);
       });
 
-      it('writes to _buffer if a Buffer is supplied', function() {
+      it('writes to _buffer if a Buffer is supplied', function () {
         var payload1 = 'payload1';
         response.end(new Buffer(payload1));
         var buffer = response._getBuffer();
@@ -1158,14 +1158,14 @@ describe('mockResponse', function() {
 
   });
 
-  describe('write() + end() interactions', function() {
+  describe('write() + end() interactions', function () {
     var response;
 
-    beforeEach(function() {
+    beforeEach(function () {
       response = mockResponse.createResponse();
     });
 
-    it('should accept strings through write() and end() and concatenate them in _data', function() {
+    it('should accept strings through write() and end() and concatenate them in _data', function () {
       var payload1 = 'payload1';
       var payload2 = 'payload2';
       response.write(payload1);
@@ -1173,7 +1173,7 @@ describe('mockResponse', function() {
       expect(response._getData()).to.equal(payload1 + payload2);
     });
 
-    it('should accept buffers through write() and end() and concatenate them in _buffer', function() {
+    it('should accept buffers through write() and end() and concatenate them in _buffer', function () {
       var payload1 = 'payload1';
       var payload2 = 'payload2';
       response.write(new Buffer(payload1));
@@ -1185,15 +1185,15 @@ describe('mockResponse', function() {
   });
 
   // TODO: fix in 2.0; methods should be inherited from Node WritableStream
-  describe('node WritableStream methods', function() {
+  describe('node WritableStream methods', function () {
 
-    describe('.destroy()', function() {
+    describe('.destroy()', function () {
 
       it('should inherit from Node WritableStream.destroy()');
 
     });
 
-    describe('.destroySoon()', function() {
+    describe('.destroySoon()', function () {
 
       it('should inherit from Node WritableStream.destroySoon()');
 
@@ -1202,57 +1202,57 @@ describe('mockResponse', function() {
   });
 
   // TODO: fix in 2.0; methods should be inherited from Node EventEmitter
-  describe('node EventEmitter methods', function() {
+  describe('node EventEmitter methods', function () {
 
-    describe('.addListener()', function() {
+    describe('.addListener()', function () {
 
       it('should inherit from Node EventEmitter.addListener()');
 
     });
 
-    describe('.on()', function() {
+    describe('.on()', function () {
 
       it('should inherit from Node EventEmitter.on()');
 
     });
 
-    describe('.once()', function() {
+    describe('.once()', function () {
 
       it('should inherit from Node EventEmitter.once()');
 
     });
 
-    describe('.removeListener()', function() {
+    describe('.removeListener()', function () {
 
       it('should inherit from Node EventEmitter.removeListener()');
 
     });
 
-    describe('.removeAllListeners()', function() {
+    describe('.removeAllListeners()', function () {
 
       it('should inherit from Node EventEmitter.removeAllListeners()');
 
     });
 
-    describe('.setMaxListeners()', function() {
+    describe('.setMaxListeners()', function () {
 
       it('should inherit from Node EventEmitter.setMaxListeners()');
 
     });
 
-    describe('.listeners()', function() {
+    describe('.listeners()', function () {
 
       it('should inherit from Node EventEmitter.listeners()');
 
     });
 
-    describe('.emit()', function() {
+    describe('.emit()', function () {
 
       it('should inherit from Node EventEmitter.emit()');
 
     });
 
-    describe('.prependListener()', function() {
+    describe('.prependListener()', function () {
 
       it('should inherit from Node EventEmitter.prependListener()');
 
@@ -1261,41 +1261,41 @@ describe('mockResponse', function() {
   });
 
   // TODO: deprecate helper methods in 2.0
-  describe('helper methods', function() {
+  describe('helper methods', function () {
     var response;
 
-    beforeEach(function() {
+    beforeEach(function () {
       response = mockResponse.createResponse();
     });
 
-    afterEach(function() {
+    afterEach(function () {
       response = null;
     });
 
-    describe('._isEndCalled()', function() {
+    describe('._isEndCalled()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return false when .end() hasn\'t been called', function() {
+      it('should return false when .end() hasn\'t been called', function () {
         expect(response._isEndCalled()).to.be.false;
       });
 
-      it('should return true when .end() has been called', function() {
+      it('should return true when .end() has been called', function () {
         response.end();
         expect(response._isEndCalled()).to.be.true;
       });
 
     });
 
-    describe('._getHeaders()', function() {
+    describe('._getHeaders()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return empty object when no headers have been set', function() {
+      it('should return empty object when no headers have been set', function () {
         expect(response._getHeaders()).to.deep.equal({});
       });
 
-      it('should return true when .end() has been called', function() {
+      it('should return true when .end() has been called', function () {
         var headers = {
           'content-type': 'text/plain'
         };
@@ -1305,13 +1305,13 @@ describe('mockResponse', function() {
 
     });
 
-    describe('._getLocals()', function() {
+    describe('._getLocals()', function () {
 
-      it('should return empty object when no locals have been set', function() {
+      it('should return empty object when no locals have been set', function () {
         expect(response._getLocals()).to.deep.equal({});
       });
 
-      it('should set the locals -object correctly', function() {
+      it('should set the locals -object correctly', function () {
         var locals = {
           token: 'Test'
         };
@@ -1321,114 +1321,114 @@ describe('mockResponse', function() {
 
     });
 
-    describe('._getData()', function() {
+    describe('._getData()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return empty string when no data has been sent', function() {
+      it('should return empty string when no data has been sent', function () {
         expect(response._getData()).to.equal('');
       });
 
-      it('should return sent data', function() {
+      it('should return sent data', function () {
         response.send('data');
         expect(response._getData()).to.equal('data');
       });
 
     });
 
-    describe('._getJSONData()', function() {
+    describe('._getJSONData()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return sent data', function() {
-        var data = { a: 1, b: { c: 2 }};
+      it('should return sent data', function () {
+        var data = { a: 1, b: { c: 2 } };
         response.send(JSON.stringify(data));
         expect(response._getJSONData()).to.deep.equal(data);
       });
 
     });
 
-    describe('._getStatusCode()', function() {
+    describe('._getStatusCode()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return default status code, when not set', function() {
+      it('should return default status code, when not set', function () {
         expect(response._getStatusCode()).to.equal(200);
       });
 
-      it('should return set status code', function() {
+      it('should return set status code', function () {
         response.status(404);
         expect(response._getStatusCode()).to.equal(404);
       });
 
     });
 
-    describe('._getStatusMessage()', function() {
+    describe('._getStatusMessage()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return the default status message, when not set', function() {
+      it('should return the default status message, when not set', function () {
         expect(response._getStatusMessage()).to.equal('OK');
       });
 
-      it('should return set status message', function() {
+      it('should return set status message', function () {
         response.statusMessage = 'NotOK';
         expect(response._getStatusMessage()).to.equal('NotOK');
       });
 
-      it('should return status message set by .writeHead()', function() {
+      it('should return status message set by .writeHead()', function () {
         response.writeHead(400, 'NotOK');
         expect(response._getStatusMessage()).to.equal('NotOK');
       });
 
     });
 
-    describe('._isJSON()', function() {
+    describe('._isJSON()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return true, when Content-Type is JSON', function() {
+      it('should return true, when Content-Type is JSON', function () {
         response.type('json');
         expect(response._isJSON()).to.be.true;
       });
 
-      it('should return false, when Content-Type is not JSON', function() {
+      it('should return false, when Content-Type is not JSON', function () {
         response.type('html');
         expect(response._isJSON()).to.be.false;
       });
 
     });
 
-    describe('._isUTF8()', function() {
+    describe('._isUTF8()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return false, when enconding is not UTF-8', function() {
+      it('should return false, when enconding is not UTF-8', function () {
         expect(response._isUTF8()).to.be.false;
       });
 
-      it('should return true, when enconding is UTF-8', function() {
+      it('should return true, when enconding is UTF-8', function () {
         response.setEncoding('utf8');
         expect(response._isUTF8()).to.be.true;
       });
 
     });
 
-    describe('._isDataLengthValid()', function() {
+    describe('._isDataLengthValid()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return true, when Content-Length not present', function() {
+      it('should return true, when Content-Length not present', function () {
         expect(response._isDataLengthValid()).to.be.true;
       });
 
-      it('should return true, when Content-Length equals data size', function() {
+      it('should return true, when Content-Length equals data size', function () {
         response.send('data');
         response.header('Content-Length', '4');
         expect(response._isDataLengthValid()).to.be.true;
       });
 
-      it('should return false, when Content-Length does not equal data size', function() {
+      it('should return false, when Content-Length does not equal data size', function () {
         response.send('data');
         response.header('Content-Length', '5');
         expect(response._isDataLengthValid()).to.be.false;
@@ -1436,15 +1436,15 @@ describe('mockResponse', function() {
 
     });
 
-    describe('._getRedirectUrl()', function() {
+    describe('._getRedirectUrl()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return empty string, when .redirect() not called', function() {
+      it('should return empty string, when .redirect() not called', function () {
         expect(response._getRedirectUrl()).to.equal('');
       });
 
-      it('should return redirect url', function() {
+      it('should return redirect url', function () {
         var url = '/path/to/redirect';
         response.redirect(url);
         expect(response._getRedirectUrl()).to.equal(url);
@@ -1452,15 +1452,15 @@ describe('mockResponse', function() {
 
     });
 
-    describe('._getRenderView()', function() {
+    describe('._getRenderView()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return empty string, when .render() not called', function() {
+      it('should return empty string, when .render() not called', function () {
         expect(response._getRenderView()).to.equal('');
       });
 
-      it('should return name of rendered view', function() {
+      it('should return name of rendered view', function () {
         var view = 'view';
         response.render(view);
         expect(response._getRenderView()).to.equal(view);
@@ -1468,20 +1468,20 @@ describe('mockResponse', function() {
 
     });
 
-    describe('._getRenderData()', function() {
+    describe('._getRenderData()', function () {
 
       it('will be deprecated in 2.0');
 
-      it('should return empty object, when .render() not called', function() {
+      it('should return empty object, when .render() not called', function () {
         expect(response._getRenderData()).to.deep.equal({});
       });
 
-      it('should return empty object, when .render() called without data', function() {
+      it('should return empty object, when .render() called without data', function () {
         response.render('view');
         expect(response._getRenderData()).to.deep.equal({});
       });
 
-      it('should return data object, when .render() called with data', function() {
+      it('should return data object, when .render() called with data', function () {
         var data = {
           key: 'value'
         };

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -843,7 +843,7 @@ describe('mockResponse', function() {
 
         expect(response.statusCode).to.equal(200);
         expect(response.statusMessage).to.equal('OK');
-        expect(response._getHeaders()).to.be.empty;
+        expect(response.getHeaders()).to.be.empty;
       });
 
       afterEach(function() {
@@ -865,7 +865,7 @@ describe('mockResponse', function() {
       it('writes the headers of the response', function() {
         var headers = { 'x-header': 'test llama' };
         response.writeHead(400, headers);
-        expect(response._getHeaders()).to.deep.equal(headers);
+        expect(response.getHeaders()).to.deep.equal(headers);
       });
 
       it('updates the headersSent property of the response', function() {
@@ -880,34 +880,34 @@ describe('mockResponse', function() {
         // in real life.
         response.writeHead(500, {'x-header': 'llama party'});
         // Should still see same as before
-        expect(response._getHeaders()).to.deep.equal(headers);
+        expect(response.getHeaders()).to.deep.equal(headers);
       });
 
       it('works with statusMessage and headers as optional', function() {
         response.writeHead(400);
         expect(response.statusCode).to.equal(400);
         expect(response.statusMessage).to.equal('OK');
-        expect(response._getHeaders()).to.be.empty;
+        expect(response.getHeaders()).to.be.empty;
       });
 
       it('works with statusMessage as optional', function() {
         var headers = { 'x-header': 'test llama' };
         response.writeHead(400, headers);
         expect(response.statusMessage).to.equal('OK');
-        expect(response._getHeaders()).to.deep.equal(headers);
+        expect(response.getHeaders()).to.deep.equal(headers);
       });
 
       it('works with headers as optional', function() {
         response.writeHead(400, 'NotOK');
         expect(response.statusMessage).to.equal('NotOK');
-        expect(response._getHeaders()).to.be.empty;
+        expect(response.getHeaders()).to.be.empty;
       });
 
       it('works with statusCode, statusMessage, and headers defined', function() {
         var headers = { 'x-header': 'test llama' };
         response.writeHead(400, 'NotOK', headers);
         expect(response.statusMessage).to.equal('NotOK');
-        expect(response._getHeaders()).to.deep.equal(headers);
+        expect(response.getHeaders()).to.deep.equal(headers);
       });
 
       it('throws if end has already been called', function() {
@@ -918,7 +918,7 @@ describe('mockResponse', function() {
       it('merges the given headers with the ones specified earlier (set with `setHeader`)', function() {
         response.setHeader('Access-Control-Allow-Origin', '*');
         response.writeHead(200, {'Access-Control-Max-Age': '86400'});
-        expect(response._getHeaders()).to.contain.all.keys({'access-control-allow-origin': '*', 'access-control-max-age': '86400'});
+        expect(response.getHeaders()).to.contain.all.keys({'access-control-allow-origin': '*', 'access-control-max-age': '86400'});
       });
 
     });


### PR DESCRIPTION
As commented in #211, I have just implemented the `response.getHeaders()` method (defined in `OutgoingMessage`).

[Node.js specification](https://nodejs.org/docs/latest-v10.x/api/http.html#http_response_getheaders) says the method returns a shallow copy, so I serialize and parse the internal `_headers` object before returning it to avoid additional dependencies.