### PR TITLE
Fix gulp-eslint errors

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -506,15 +506,16 @@ function createRequest(options) {
      *    Subdomains are the dot-separated parts of the host before the main domain of the app.
      *
      */
-    mockRequest.subdomains = (() => {
-
-        if (!mockRequest.headers.host) return [];
+    mockRequest.subdomains = (function() {
+        if (!mockRequest.headers.host) {
+            return [];
+        }
 
         var offset = 2;
-        const subdomains = mockRequest.headers.host.split('.').reverse();
+        var subdomains = mockRequest.headers.host.split('.').reverse();
 
         return subdomains.slice(offset);
-    })()
+    }());
     
     return mockRequest;
 }


### PR DESCRIPTION
The latest pull request #213 added some code that does not satisfy `gulp-eslint` requirements. I have changed a few things to solve the errors and unblock #217:

- Use a regular function instead of an arrow one.
- Wrap if block into brackets.
- Replace `const` with `var`.