### PR TITLE
Remove calls to deprecated Buffer constructors

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -39,7 +39,7 @@ function createResponse(options) {
 
     var _endCalled = false;
     var _data = '';
-    var _buffer = new Buffer(0);
+    var _buffer = Buffer.alloc(0);
     var _chunks = [];
     var _size = 0;
     var _encoding = options.encoding;
@@ -413,7 +413,7 @@ function createResponse(options) {
                     _buffer = _chunks[0];
                     break;
                 default:
-                    _buffer = new Buffer(_size);
+                    _buffer = Buffer.alloc(_size);
                     for (var i = 0, pos = 0, l = _chunks.length; i < l; i++) {
                         var chunk = _chunks[i];
                         chunk.copy(_buffer, pos);

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -1090,7 +1090,7 @@ describe('mockResponse', function () {
 
       it('should accept a buffer and hold it in _chunks', function () {
         var payload1 = 'payload1';
-        response.write(new Buffer(payload1));
+        response.write(Buffer.from(payload1));
         var chunks = response._getChunks();
         expect(chunks.length).to.eql(1);
         expect(chunks[0].toString()).to.equal(payload1);
@@ -1099,8 +1099,8 @@ describe('mockResponse', function () {
       it('should accept multiple buffers and hold them in _chunks', function () {
         var payload1 = 'payload1';
         var payload2 = 'payload2';
-        response.write(new Buffer(payload1));
-        response.write(new Buffer(payload2));
+        response.write(Buffer.from(payload1));
+        response.write(Buffer.from(payload2));
         var chunks = response._getChunks();
         expect(chunks.length).to.eql(2);
         expect(chunks[0].toString()).to.equal(payload1);
@@ -1147,7 +1147,7 @@ describe('mockResponse', function () {
 
       it('writes to _buffer if a Buffer is supplied', function () {
         var payload1 = 'payload1';
-        response.end(new Buffer(payload1));
+        response.end(Buffer.from(payload1));
         var buffer = response._getBuffer();
         expect(buffer.toString()).to.equal(payload1);
       });
@@ -1176,8 +1176,8 @@ describe('mockResponse', function () {
     it('should accept buffers through write() and end() and concatenate them in _buffer', function () {
       var payload1 = 'payload1';
       var payload2 = 'payload2';
-      response.write(new Buffer(payload1));
-      response.end(new Buffer(payload2));
+      response.write(Buffer.from(payload1));
+      response.end(Buffer.from(payload2));
       var buffer = response._getBuffer();
       expect(buffer.toString()).to.equal(payload1 + payload2);
     });


### PR DESCRIPTION
Constructors [new Buffer(string)](https://nodejs.org/docs/latest-v6.x/api/buffer.html#buffer_new_buffer_string_encoding) and [new Buffer(size)](https://nodejs.org/docs/latest-v6.x/api/buffer.html#buffer_new_buffer_size) have been deprecated a long time ago.

`npm run test` emits a `DeprecationWarning` because the library uses it for both implementation and unit tests.
> (node:2104) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

This pull request replaces those deprecated methods with the new recommended ones.