### PR TITLE
New response methods for headers retrieval

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -556,6 +556,15 @@ function createResponse(options) {
     };
 
     /**
+     * Function: hasHeader
+     *
+     *   Returns `true` if the header identified by `name` is currently set.
+     */
+    mockResponse.hasHeader = function(name) {
+        return name.toLowerCase() in mockResponse._headers;
+    };
+
+    /**
      * Function: setHeader
      * Function: set
      *

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -547,6 +547,15 @@ function createResponse(options) {
     };
 
     /**
+     * Function: getHeaderNames
+     *
+     *   Returns an array containing the unique names of the current outgoing headers.
+     */
+    mockResponse.getHeaderNames = function() {
+        return Object.keys(mockResponse._headers); // names are already stored in lowercase
+    };
+
+    /**
      * Function: setHeader
      * Function: set
      *

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -1021,11 +1021,11 @@ describe('mockResponse', function () {
         response = null;
       });
 
-      it('should return an empty object when no cookies were set', function () {
+      it('should return an empty object when no headers were set', function () {
         expect(response.getHeaders()).to.deep.equal({});
       });
 
-      it('should return cookies previously set', function () {
+      it('should return headers previously set', function () {
         response.setHeader('name1', 'value1');
         response.setHeader('name2', 'value2');
 

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -987,6 +987,29 @@ describe('mockResponse', function () {
 
     });
 
+    describe('.getHeaderNames()', function () {
+      var response;
+
+      beforeEach(function () {
+        response = mockResponse.createResponse();
+      });
+
+      afterEach(function () {
+        response = null;
+      });
+
+      it('should return an empty array when no headers were set', function () {
+        expect(response.getHeaderNames()).to.deep.equal([]);
+      });
+
+      it('should return names of headers previously set', function () {
+        response.setHeader('name1', 'value1');
+        response.setHeader('name2', 'value2');
+
+        expect(response.getHeaderNames()).to.deep.equal(['name1', 'name2']);
+      });
+    });
+
     describe('.getHeaders()', function () {
       var response;
 

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -1046,6 +1046,32 @@ describe('mockResponse', function () {
       });
     });
 
+    describe('.hasHeader()', function () {
+      var response;
+
+      beforeEach(function () {
+        response = mockResponse.createResponse();
+      });
+
+      afterEach(function () {
+        response = null;
+      });
+
+      it('should return true if the header was set', function () {
+        response.setHeader('name1');
+        expect(response.hasHeader('name1')).to.be.true;
+      });
+
+      it('should return false if the header is missing', function () {
+        expect(response.hasHeader('name1')).to.be.false;
+      });
+
+      it('should be case-insensitive', function () {
+        response.setHeader('name1');
+        expect(response.hasHeader('NAME1')).to.be.true;
+      });
+    });
+
     describe('.removeHeader()', function () {
       var response;
 


### PR DESCRIPTION
- Implement `response.getHeaderNames()` according to [spec](https://nodejs.org/api/http.html#http_response_getheadernames).
- Implement `response.hasHeader()` according to [spec](https://nodejs.org/api/http.html#http_response_hasheader_name).
- Fix typos in the names of several unit tests (#217).