### PR TITLE
feat: add support for req.hostname

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -501,6 +501,24 @@ function createRequest(options) {
     };
 
     /**
+     * Function: hostname
+     *
+     *    Hostname is the main domain of the host without the subdomains and port.
+     *
+     */
+    mockRequest.hostname = (function() {
+        if (!mockRequest.headers.host) {
+            return '';
+        }
+
+        var offset = 2;
+        var hostname = mockRequest.headers.host.split(':')[0].split('.');
+        var start = hostname.length - offset;
+        var end = hostname.length;
+        return hostname.slice(start, end).join('.');
+    }());
+
+    /**
      * Function: subdomains
      *
      *    Subdomains are the dot-separated parts of the host before the main domain of the app.

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -881,6 +881,47 @@ describe('mockRequest', function() {
 
     });
 
+    describe('.hostname', function() {
+
+      it('should return the host\'s main domain', function() {
+        var options = {
+          headers: {
+            host: 'tobi.ferrets.example.com:5000'
+          }
+        };
+        request = mockRequest.createRequest(options);
+        expect(request.hostname).to.equal('example.com');
+
+        options.headers.host = 'tobi.ferrets.example.com';
+        request = mockRequest.createRequest(options);
+        expect(request.hostname).to.equal('example.com');
+
+        options.headers.host = 'example.com';
+        request = mockRequest.createRequest(options);
+        expect(request.hostname).to.equal('example.com');
+
+        options.headers.host = 'example.com:8443';
+        request = mockRequest.createRequest(options);
+        expect(request.hostname).to.equal('example.com');
+
+        options.headers.host = 'localhost:3000';
+        request = mockRequest.createRequest(options);
+        expect(request.hostname).to.equal('localhost');
+
+      });
+
+      it('should return an empty string', function () {
+        var options = {
+          headers: {
+            key1: 'key1'
+          }
+        };
+        request = mockRequest.createRequest(options);
+        expect(request.hostname).to.equal('');
+      });
+
+    });
+
     describe('.subdomains', function() {
 
       it('should returns the host subdomains', function() {


### PR DESCRIPTION
This will add support for `req.hostname` specified in the expressjs documentation: http://expressjs.com/en/5x/api.html#req.hostname

**Note:** I didn't implement the X-Forwarded-Host check since we would need to evaluate the `trust proxy` option: http://expressjs.com/en/5x/api.html#app.set