### PR TITLE
Fix req.hostname to make it compatible with Express.js

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -478,7 +478,7 @@ function createRequest(options) {
         mockRequest.body[key] = value;
     };
 
-    
+
     /**
      * Function: send
      *
@@ -489,7 +489,7 @@ function createRequest(options) {
      *   data - string, array, object, number, buffer
      */
     mockRequest.send = function(data) {
-        
+
         if(Buffer.isBuffer(data)){
             this.emit('data', data);
         }else if(typeof data === 'object' || typeof data === 'number'){
@@ -503,20 +503,19 @@ function createRequest(options) {
     /**
      * Function: hostname
      *
-     *    Hostname is the main domain of the host without the subdomains and port.
+     * If Hostname is not set explicitly, then derive it from the Host header without port information
      *
      */
-    mockRequest.hostname = (function() {
-        if (!mockRequest.headers.host) {
-            return '';
-        }
+    if (!mockRequest.hostname) {
+        mockRequest.hostname = (function() {
+            if (!mockRequest.headers.host) {
+                return '';
+            }
 
-        var offset = 2;
-        var hostname = mockRequest.headers.host.split(':')[0].split('.');
-        var start = hostname.length - offset;
-        var end = hostname.length;
-        return hostname.slice(start, end).join('.');
-    }());
+            var hostname = mockRequest.headers.host.split(':')[0].split('.');
+            return hostname.join('.');
+        }());
+    }
 
     /**
      * Function: subdomains
@@ -534,7 +533,7 @@ function createRequest(options) {
 
         return subdomains.slice(offset);
     }());
-    
+
     return mockRequest;
 }
 

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -460,7 +460,7 @@ describe('mockRequest', function() {
       request = mockRequest.createRequest();
       expect(request.range()).to.be.undefined;
     });
-    
+
     var tests = [
       {
         // Unsatisfiable
@@ -890,11 +890,11 @@ describe('mockRequest', function() {
           }
         };
         request = mockRequest.createRequest(options);
-        expect(request.hostname).to.equal('example.com');
+        expect(request.hostname).to.equal('tobi.ferrets.example.com');
 
         options.headers.host = 'tobi.ferrets.example.com';
         request = mockRequest.createRequest(options);
-        expect(request.hostname).to.equal('example.com');
+        expect(request.hostname).to.equal('tobi.ferrets.example.com');
 
         options.headers.host = 'example.com';
         request = mockRequest.createRequest(options);
@@ -918,6 +918,17 @@ describe('mockRequest', function() {
         };
         request = mockRequest.createRequest(options);
         expect(request.hostname).to.equal('');
+      });
+
+      it('should return an predefined hostname', function () {
+        var options = {
+          hostname: 'predefined.host.com',
+          headers: {
+            host: 'other.host'
+          }
+        };
+        request = mockRequest.createRequest(options);
+        expect(request.hostname).to.equal('predefined.host.com');
       });
 
     });


### PR DESCRIPTION
Hostname includes full domain name with all the subdomains
If Hostname is predefined, then Host header is ignored (to prevent backwards-incompatible changes)

Fixes #230