### PR TITLE
Fix res._isJSON() to correctly support content type with vendor prefix

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -24,7 +24,7 @@
  *
  *   encoding - The default encoding for the response
  */
-
+var typeis = require('type-is');
 var WritableStream = require('./mockWritableStream');
 var EventEmitter = require('./mockEventEmitter');
 var mime = require('mime');
@@ -812,7 +812,7 @@ function createResponse(options) {
      *  It doesn't validate the data that was sent.
      */
     mockResponse._isJSON = function() {
-        return mockResponse.getHeader('Content-Type') === 'application/json';
+        return Boolean(typeis.is(mockResponse.getHeader('Content-Type'), ['json', 'application/*+json']));
     };
 
     /**

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -1441,6 +1441,11 @@ describe('mockResponse', function () {
         expect(response._isJSON()).to.be.true;
       });
 
+      it('should return true, when Content-Type is JSON with vendor prefix', function () {
+        response.type('application/hal+json');
+        expect(response._isJSON()).to.be.true;
+      });
+
       it('should return false, when Content-Type is not JSON', function () {
         response.type('html');
         expect(response._isJSON()).to.be.false;


### PR DESCRIPTION
This makes sure `application/hal+json` content type is also detected as JSON.

Fixes #238