### PR TITLE
Fix request.ip and add request.ips

### DIFF
--- a/lib/express/mock-request.js
+++ b/lib/express/mock-request.js
@@ -95,10 +95,6 @@ defineGetter(req, 'secure', function secure(){
     return this.protocol === 'https';
 });
 
-defineGetter(req, 'ip', function ip(){
-    return this.options.ip;
-});
-
 defineGetter(req, 'subdomains', function subdomains() {
     var hostname = this.hostname;
 

--- a/lib/express/mock-request.js
+++ b/lib/express/mock-request.js
@@ -95,6 +95,14 @@ defineGetter(req, 'secure', function secure(){
     return this.protocol === 'https';
 });
 
+defineGetter(req, 'ip', function ip(){
+    return this.options.ip || '127.0.0.1';
+});
+
+defineGetter(req, 'ips', function ips(){
+    return [this.ip];
+});
+
 defineGetter(req, 'subdomains', function subdomains() {
     var hostname = this.hostname;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -101,6 +101,7 @@ declare module 'node-mocks-http' {
         body?: Body;
         query?: Query;
         files?: Files;
+        ip?: string;
 
         // Support custom properties appended on Request objects.
         [key: string]: any;

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -75,6 +75,9 @@ function createRequest(options) {
     mockRequest.files = options.files ? options.files : {};
     mockRequest.socket = options.socket ? options.socket : {};
 
+    mockRequest.ip = options.ip || '127.0.0.1';
+    mockRequest.ips = [mockRequest.ip];
+
     //parse query string from url to object
     if (Object.keys(mockRequest.query).length === 0) {
         mockRequest.query = require('querystring').parse(mockRequest.url.split('?')[1]);

--- a/test/lib/mockRequest.spec.js
+++ b/test/lib/mockRequest.spec.js
@@ -62,6 +62,8 @@ describe('mockRequest', function() {
         expect(request.body).to.deep.equal({});
         expect(request.query).to.deep.equal({});
         expect(request.files).to.deep.equal({});
+        expect(request.ip).to.equal('127.0.0.1');
+        expect(request.ips).to.deep.equal([request.ip]);
       });
 
     });
@@ -269,6 +271,24 @@ describe('mockRequest', function() {
 
         request = mockRequest.createRequest(options);
         expect(request.mySampleProp).to.equal('la LA LA');
+      });
+
+      it('should set .ip to options.ip', function() {
+        var options = {
+          ip: '192.168.1.1'
+        };
+
+        request = mockRequest.createRequest(options);
+        expect(request.ip).to.equal(options.ip);
+      });
+
+      it('should set .ips to [options.ip]', function() {
+        var options = {
+          ip: '192.168.1.1'
+        };
+
+        request = mockRequest.createRequest(options);
+        expect(request.ips).to.deep.equal([options.ip]);
       });
 
     });


### PR DESCRIPTION
**Changes:**

According to `express` interface, the `request.ip` property must be always defined, so I have set `127.0.0.1` as the default value.

Additionally, I have also implemented the `request.ips` property.


**Note:**

Formally `request.ip` is defined as `request.ips[0]` but I made the decision to simplify the `RequestOptions` interface accepting only the `ip` property because it is the common case and it avoids inconsistencies between both options (when someone specifies an `ip` that is not the first element of `ips`).