### PR TITLE
Add response.attachment() from express

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -30,6 +30,8 @@ var EventEmitter = require('./mockEventEmitter');
 var mime = require('mime');
 var http = require('./node/http');
 var utils = require('./utils');
+var path = require('path');
+var contentDisposition = require('content-disposition');
 
 function createResponse(options) {
 
@@ -463,6 +465,28 @@ function createResponse(options) {
         values = values.concat(fields);
 
         return mockResponse.setHeader('Vary', values.join(', '));
+    };
+
+    /**
+     * Set _Content-Disposition_ header to _attachment_ with optional `filename`.
+     * 
+     * Example:
+     * 
+     *      res.attachment('download.csv')
+     *
+     * @param {String} filename
+     * @return {ServerResponse}
+     * @api public
+     */
+
+    mockResponse.attachment = function attachment(filename) {
+        if (filename) {
+            mockResponse.type(path.extname(filename));
+        }
+    
+        mockResponse.set('Content-Disposition', contentDisposition(filename));
+    
+        return this;
     };
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -933,6 +933,21 @@
         "typedarray": "^0.0.6"
       }
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "accepts": "^1.3.7",
+    "content-disposition": "^0.5.3",
     "depd": "^1.1.0",
     "fresh": "^0.5.2",
     "merge-descriptors": "^1.0.1",

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -74,6 +74,9 @@ describe('mockResponse', function () {
 
       expect(response).to.have.property('render');
       expect(response.render).to.be.a('function');
+
+      expect(response).to.have.property('attachment');
+      expect(response.render).to.be.a('function');
     });
 
     it('should expose Node OutgoingMessage methods', function () {
@@ -828,6 +831,21 @@ describe('mockResponse', function () {
         var defaultSpy = sinon.spy();
         response.format({ default: defaultSpy });
         expect(defaultSpy).to.have.been.called;
+      });
+    });
+
+    describe('.attachment()', function () {
+      var response;
+
+      beforeEach(function () {
+        response = mockResponse.createResponse();
+      });
+
+      it('adds Content-Disposition header', function () {
+        response.attachment('download.csv');
+
+        expect(response._headers).to.have.property('content-disposition');
+        expect(response._headers['content-disposition']).to.be.equal('attachment; filename="download.csv"');
       });
     });
   });


### PR DESCRIPTION
Add support for the express function response.attachment(). Original code is [here](https://github.com/expressjs/express/blob/508936853a6e311099c9985d4c11a4b1b8f6af07/lib/response.js#L688). It's just a pretty simple shorthand function. First pull request so let me know if there are any style issues!