### PR TITLE
Make it easier to create mocks for the node http library

### DIFF
--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -78,6 +78,8 @@ function createRequest(options) {
     mockRequest.ip = options.ip || '127.0.0.1';
     mockRequest.ips = [mockRequest.ip];
 
+    mockRequest.destroy = () => {};
+    
     //parse query string from url to object
     if (Object.keys(mockRequest.query).length === 0) {
         mockRequest.query = require('querystring').parse(mockRequest.url.split('?')[1]);


### PR DESCRIPTION
This is to prevent the need for me to set the destroy function handler myself when creating a request for the http library. Since the destroy function returns void we can just mock it as an empty function and don't need to action anything.

I'm not actually using express but this library is working for me with the core http library. This change saves me 1 line of additional code and makes it easier for other people using the library that aren't using express.

Before:
```js
const mockRequest = httpMocks.createRequest();

mockRequest.destroy = jest.fn();

const mockResponse = httpMocks.createResponse();

handleRequest(mockRequest, mockResponse);
```

After:
```js
const mockRequest = httpMocks.createRequest();

const mockResponse = httpMocks.createResponse();

handleRequest(mockRequest, mockResponse);
```