### PR TITLE
feat(types): Add `QUERY` to `RequestMethod` union

### DIFF
--- a/lib/http-mock.d.ts
+++ b/lib/http-mock.d.ts
@@ -4,7 +4,7 @@ import { IncomingMessage, OutgoingMessage } from 'http';
 export type RequestType = IncomingMessage | globalThis.Request;
 export type ResponseType<ResBody = any> = OutgoingMessage | globalThis.Response | Response<ResBody>;
 
-export type RequestMethod = 'CONNECT' | 'DELETE' | 'GET' | 'HEAD' | 'OPTIONS' | 'PATCH' | 'POST' | 'PUT' | 'TRACE';
+export type RequestMethod = 'CONNECT' | 'DELETE' | 'GET' | 'HEAD' | 'OPTIONS' | 'PATCH' | 'POST' | 'PUT' | 'QUERY' | 'TRACE';
 
 export interface Params {
     [key: string]: any;

--- a/lib/http-mock.d.ts
+++ b/lib/http-mock.d.ts
@@ -4,7 +4,17 @@ import { IncomingMessage, OutgoingMessage } from 'http';
 export type RequestType = IncomingMessage | globalThis.Request;
 export type ResponseType<ResBody = any> = OutgoingMessage | globalThis.Response | Response<ResBody>;
 
-export type RequestMethod = 'CONNECT' | 'DELETE' | 'GET' | 'HEAD' | 'OPTIONS' | 'PATCH' | 'POST' | 'PUT' | 'QUERY' | 'TRACE';
+export type RequestMethod =
+    | 'CONNECT'
+    | 'DELETE'
+    | 'GET'
+    | 'HEAD'
+    | 'OPTIONS'
+    | 'PATCH'
+    | 'POST'
+    | 'PUT'
+    | 'QUERY'
+    | 'TRACE';
 
 export interface Params {
     [key: string]: any;

--- a/test/lib/http-mock.test-d.ts
+++ b/test/lib/http-mock.test-d.ts
@@ -4,7 +4,15 @@ import { expectAssignable, expectNotAssignable, expectNotType, expectType } from
 // eslint-disable-next-line import/no-unresolved
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 
-import { createMocks, createRequest, createResponse, MockRequest, MockResponse, Mocks, RequestMethod } from '../../lib/http-mock';
+import {
+    createMocks,
+    createRequest,
+    createResponse,
+    MockRequest,
+    MockResponse,
+    Mocks,
+    RequestMethod
+} from '../../lib/http-mock';
 
 expectType<MockRequest<ExpressRequest>>(createRequest());
 expectNotType<MockRequest<NodeRequest>>(createRequest());
@@ -41,14 +49,14 @@ expectType<Mocks<ExpressRequest, ExpressResponse<{ message: number }>>>(
     createMocks<ExpressRequest, ExpressResponse<{ message: number }>>()
 );
 
-expectAssignable<RequestMethod>("CONNECT");
-expectAssignable<RequestMethod>("DELETE");
-expectAssignable<RequestMethod>("GET");
-expectAssignable<RequestMethod>("HEAD");
-expectAssignable<RequestMethod>("OPTIONS");
-expectAssignable<RequestMethod>("PATCH");
-expectAssignable<RequestMethod>("POST");
-expectAssignable<RequestMethod>("PUT");
-expectAssignable<RequestMethod>("QUERY");
-expectAssignable<RequestMethod>("TRACE");
-expectNotAssignable<RequestMethod>("WRONG");
+expectAssignable<RequestMethod>('CONNECT');
+expectAssignable<RequestMethod>('DELETE');
+expectAssignable<RequestMethod>('GET');
+expectAssignable<RequestMethod>('HEAD');
+expectAssignable<RequestMethod>('OPTIONS');
+expectAssignable<RequestMethod>('PATCH');
+expectAssignable<RequestMethod>('POST');
+expectAssignable<RequestMethod>('PUT');
+expectAssignable<RequestMethod>('QUERY');
+expectAssignable<RequestMethod>('TRACE');
+expectNotAssignable<RequestMethod>('WRONG');

--- a/test/lib/http-mock.test-d.ts
+++ b/test/lib/http-mock.test-d.ts
@@ -4,7 +4,7 @@ import { expectAssignable, expectNotAssignable, expectNotType, expectType } from
 // eslint-disable-next-line import/no-unresolved
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 
-import { createMocks, createRequest, createResponse, MockRequest, MockResponse, Mocks } from '../../lib/http-mock';
+import { createMocks, createRequest, createResponse, MockRequest, MockResponse, Mocks, RequestMethod } from '../../lib/http-mock';
 
 expectType<MockRequest<ExpressRequest>>(createRequest());
 expectNotType<MockRequest<NodeRequest>>(createRequest());
@@ -40,3 +40,15 @@ expectType<Mocks<globalThis.Request, globalThis.Response>>(createMocks<globalThi
 expectType<Mocks<ExpressRequest, ExpressResponse<{ message: number }>>>(
     createMocks<ExpressRequest, ExpressResponse<{ message: number }>>()
 );
+
+expectAssignable<RequestMethod>("CONNECT");
+expectAssignable<RequestMethod>("DELETE");
+expectAssignable<RequestMethod>("GET");
+expectAssignable<RequestMethod>("HEAD");
+expectAssignable<RequestMethod>("OPTIONS");
+expectAssignable<RequestMethod>("PATCH");
+expectAssignable<RequestMethod>("POST");
+expectAssignable<RequestMethod>("PUT");
+expectAssignable<RequestMethod>("QUERY");
+expectAssignable<RequestMethod>("TRACE");
+expectNotAssignable<RequestMethod>("WRONG");


### PR DESCRIPTION
`QUERY` method is available in Node.js ^20.19.3 and >=22.2.0 (also in `^21.7.2` but does not work properly).

This PR adds this method to the `RequestMethod` union of literals.

The QUERY method was already added to Express documentation: https://github.com/expressjs/expressjs.com/pull/2414
And I'm also adding it to the Express types: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75187
