### PR TITLE
fix(types): stop collapsing custom intersection types in createResponse/createMocks

### DIFF
--- a/lib/http-mock.d.ts
+++ b/lib/http-mock.d.ts
@@ -198,9 +198,7 @@ export type MockResponse<T extends ResponseType> = T & {
 
 export function createRequest<T extends RequestType = Request>(options?: RequestOptions): MockRequest<T>;
 
-export function createResponse<T extends ResponseType = Response>(
-    options?: ResponseOptions
-): MockResponse<T extends Response<infer ResBody> ? Response<ResBody> : T>;
+export function createResponse<T extends ResponseType = Response>(options?: ResponseOptions): MockResponse<T>;
 
 export interface Mocks<T1 extends RequestType, T2 extends ResponseType> {
     req: MockRequest<T1>;
@@ -210,11 +208,4 @@ export interface Mocks<T1 extends RequestType, T2 extends ResponseType> {
 export function createMocks<T1 extends RequestType = Request, T2 extends ResponseType = Response>(
     reqOptions?: RequestOptions,
     resOptions?: ResponseOptions
-): Mocks<
-    T1,
-    T2 extends globalThis.Response
-        ? globalThis.Response
-        : T2 extends Response<infer ResBody>
-          ? Response<ResBody>
-          : Response
->;
+): Mocks<T1, T2>;

--- a/test/lib/http-mock.test-d.ts
+++ b/test/lib/http-mock.test-d.ts
@@ -49,6 +49,31 @@ expectType<Mocks<ExpressRequest, ExpressResponse<{ message: number }>>>(
     createMocks<ExpressRequest, ExpressResponse<{ message: number }>>()
 );
 
+// A custom request type that intersects a framework interface (e.g. Next.js's
+// NextApiRequest) with MockRequest<ExpressRequest> must be preserved as-is, not
+// collapsed down to a bare ExpressRequest.
+interface CustomFrameworkRequest {
+    customFrameworkMethod: () => void;
+}
+type CustomRequest = CustomFrameworkRequest & MockRequest<ExpressRequest>;
+
+expectType<MockRequest<CustomRequest>>(createRequest<CustomRequest>());
+expectType<Mocks<CustomRequest, ExpressResponse>>(createMocks<CustomRequest, ExpressResponse>());
+
+// A custom response type that intersects a framework interface (e.g. Next.js's
+// NextApiResponse) with MockResponse<ExpressResponse> must be preserved as-is,
+// not collapsed down to a bare ExpressResponse<ResBody>.
+interface CustomFrameworkResponse {
+    customFrameworkMethod: () => void;
+}
+type CustomResponse = CustomFrameworkResponse & MockResponse<ExpressResponse<{ message: number }>>;
+
+expectType<MockResponse<CustomResponse>>(createResponse<CustomResponse>());
+expectType<Mocks<ExpressRequest, CustomResponse>>(createMocks<ExpressRequest, CustomResponse>());
+
+// Both sides can be custom intersection types at once.
+expectType<Mocks<CustomRequest, CustomResponse>>(createMocks<CustomRequest, CustomResponse>());
+
 expectAssignable<RequestMethod>('CONNECT');
 expectAssignable<RequestMethod>('DELETE');
 expectAssignable<RequestMethod>('GET');


### PR DESCRIPTION
Since 1.18.0, passing a custom response type to `createMocks<T1, T2>()` (or `createResponse<T2>()`) no longer works when `T2` is an intersection of a framework type (e.g. Next.js's `NextApiResponse`) with `MockResponse<Response<...>>`. 

The new conditional return types added in #324 / #323 (to type `_getJSONData()`) narrow `T2` down to a bare `express.Response<ResBody>` (or `globalThis.Response`), silently discarding the intended intersection with `T2`.

I believe those changes weren't needed in order to support the `_getJSONData()` typing.

This worked correctly in 1.17.2

## Reproduction
```ts
import { NextApiRequest, NextApiResponse } from "next";
import {
  createMocks as _createMocks,
  createRequest,
  createResponse,
} from "node-mocks-http";

type ApiRequest = NextApiRequest & ReturnType<typeof createRequest>;
type ApiResponse = NextApiResponse & ReturnType<typeof createResponse>;

const createMocks = (...args: Parameters<typeof _createMocks>) =>
  _createMocks<ApiRequest, ApiResponse>(...args);

// elsewhere, in a test:
const { req, res } = createMocks({ method: "GET" });
await someNextApiHandler(req, res); // <-- res no longer typechecks as NextApiResponse
```

**Expected**

`res` is typed as `MockResponse<ApiResponse>`, i.e. it still includes the `NextApiResponse` (or whatever custom interface) portion of `T2`, exactly as it was resolved before 1.18.0.

**Actual**

`res` is typed as `MockResponse<Response | e.Response<any, Record<string, any>>>` (a union of `globalThis.Response` and `express.Response`). Passing it anywhere that expects `NextApiResponse` fails with:

```
Argument of type 'MockResponse<Response | e.Response<any, Record<string, any>>>' is not assignable to parameter of type 'NextApiResponse'.
  Type '...' is missing the following properties from type 'ServerResponse<IncomingMessage>': statusCode, statusMessage, strictContentLength, assignSocket, and 67 more.
```

## This PR

This PR adds regression tests to both request and response to ensure that support for these custom intersection types are always maintained, and subsequently rolls back the changes to `createResponse` and `createMocks`.